### PR TITLE
[Unit Tests] Add tests for AvailabilityWindowChecker, SkillItemBuilder, AbilityLoreAppender

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/builder/item/ability/AbilityLoreAppenderTest.java
+++ b/src/test/java/us/eunoians/mcrpg/builder/item/ability/AbilityLoreAppenderTest.java
@@ -1,0 +1,147 @@
+package us.eunoians.mcrpg.builder.item.ability;
+
+import com.diamonddagger590.mccore.pair.Pair;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.ability.AbilityData;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityTierAttribute;
+import us.eunoians.mcrpg.ability.attribute.AbilityUnlockedAttribute;
+import us.eunoians.mcrpg.ability.impl.type.TierableAbility;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+@DisplayName("AbilityLoreAppender")
+class AbilityLoreAppenderTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("getAppendLore")
+    class GetAppendLore {
+
+        @Test
+        @DisplayName("Given no ability data on holder, returns empty lore with ability name placeholder")
+        void getAppendLore_returnsEmptyLore_whenNoAbilityData(@NotNull McRPGPlayer mcRPGPlayer) {
+            NamespacedKey abilityKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "test-ability");
+            Ability mockAbility = mock(Ability.class);
+            when(mockAbility.getAbilityKey()).thenReturn(abilityKey);
+            when(mockAbility.getName(mcRPGPlayer)).thenReturn("Test Ability");
+            when(mockAbility.getExpansionKey()).thenReturn(Optional.empty());
+
+            SkillHolder mockSkillHolder = mock(SkillHolder.class);
+            when(mockSkillHolder.getAbilityData(mockAbility)).thenReturn(Optional.empty());
+            doReturn(mockSkillHolder).when(mcRPGPlayer).asSkillHolder();
+
+            Pair<List<String>, Map<String, String>> result = AbilityLoreAppender.getAppendLore(mcRPGPlayer, mockAbility);
+
+            assertNotNull(result);
+            assertTrue(result.getLeft().isEmpty());
+            assertEquals("Test Ability", result.getRight().get("ability"));
+        }
+
+        @Test
+        @DisplayName("Given ability data present but ability is not tierable and has no expansion, returns empty lore")
+        void getAppendLore_returnsEmptyLore_whenNotTierableNoExpansion(@NotNull McRPGPlayer mcRPGPlayer) {
+            NamespacedKey abilityKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "simple-ability");
+            Ability mockAbility = mock(Ability.class);
+            when(mockAbility.getAbilityKey()).thenReturn(abilityKey);
+            when(mockAbility.getName(mcRPGPlayer)).thenReturn("Simple Ability");
+            when(mockAbility.getExpansionKey()).thenReturn(Optional.empty());
+
+            AbilityData mockData = mock(AbilityData.class);
+            SkillHolder mockSkillHolder = mock(SkillHolder.class);
+            when(mockSkillHolder.getAbilityData(mockAbility)).thenReturn(Optional.of(mockData));
+            doReturn(mockSkillHolder).when(mcRPGPlayer).asSkillHolder();
+
+            Pair<List<String>, Map<String, String>> result = AbilityLoreAppender.getAppendLore(mcRPGPlayer, mockAbility);
+
+            assertNotNull(result);
+            assertTrue(result.getLeft().isEmpty());
+            assertEquals("Simple Ability", result.getRight().get("ability"));
+        }
+
+        @Test
+        @DisplayName("Given a locked tierable ability, returns locked lore with unlock level placeholder")
+        void getAppendLore_returnsLockedLore_whenAbilityLocked(@NotNull McRPGPlayer mcRPGPlayer) {
+            addPlayerToServer(mcRPGPlayer);
+
+            NamespacedKey abilityKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "locked-ability");
+            TierableAbility mockAbility = mock(TierableAbility.class);
+            when(mockAbility.getAbilityKey()).thenReturn(abilityKey);
+            when(mockAbility.getName(mcRPGPlayer)).thenReturn("Locked Ability");
+            when(mockAbility.getExpansionKey()).thenReturn(Optional.empty());
+            when(mockAbility.getUnlockLevel()).thenReturn(10);
+
+            AbilityUnlockedAttribute unlockedAttribute = new AbilityUnlockedAttribute(false);
+
+            AbilityData mockData = mock(AbilityData.class);
+            when(mockData.getAbilityAttribute(AbilityAttributeRegistry.ABILITY_UNLOCKED_ATTRIBUTE))
+                    .thenReturn(Optional.of(unlockedAttribute));
+
+            SkillHolder mockSkillHolder = mock(SkillHolder.class);
+            when(mockSkillHolder.getAbilityData(mockAbility)).thenReturn(Optional.of(mockData));
+            doReturn(mockSkillHolder).when(mcRPGPlayer).asSkillHolder();
+
+            Pair<List<String>, Map<String, String>> result = AbilityLoreAppender.getAppendLore(mcRPGPlayer, mockAbility);
+
+            assertNotNull(result);
+            assertFalse(result.getLeft().isEmpty());
+            assertEquals("10", result.getRight().get("ability-unlock-level"));
+            assertEquals("Locked Ability", result.getRight().get("ability"));
+        }
+
+        @Test
+        @DisplayName("Given an unlocked tierable ability at max tier with no quest, returns empty lore")
+        void getAppendLore_returnsEmptyLore_whenUnlockedAtMaxTier(@NotNull McRPGPlayer mcRPGPlayer) {
+            addPlayerToServer(mcRPGPlayer);
+
+            NamespacedKey abilityKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "maxed-ability");
+            TierableAbility mockAbility = mock(TierableAbility.class);
+            when(mockAbility.getAbilityKey()).thenReturn(abilityKey);
+            when(mockAbility.getName(mcRPGPlayer)).thenReturn("Maxed Ability");
+            when(mockAbility.getExpansionKey()).thenReturn(Optional.empty());
+            when(mockAbility.getMaxTier()).thenReturn(3);
+
+            AbilityUnlockedAttribute unlockedAttribute = new AbilityUnlockedAttribute(true);
+            AbilityTierAttribute tierAttribute = new AbilityTierAttribute(3);
+
+            AbilityData mockData = mock(AbilityData.class);
+            when(mockData.getAbilityAttribute(AbilityAttributeRegistry.ABILITY_UNLOCKED_ATTRIBUTE))
+                    .thenReturn(Optional.of(unlockedAttribute));
+            when(mockData.getAbilityAttribute(AbilityAttributeRegistry.ABILITY_QUEST_ATTRIBUTE))
+                    .thenReturn(Optional.empty());
+            when(mockData.getAbilityAttribute(AbilityAttributeRegistry.ABILITY_TIER_ATTRIBUTE_KEY))
+                    .thenReturn(Optional.of(tierAttribute));
+
+            SkillHolder mockSkillHolder = mock(SkillHolder.class);
+            when(mockSkillHolder.getAbilityData(mockAbility)).thenReturn(Optional.of(mockData));
+            doReturn(mockSkillHolder).when(mcRPGPlayer).asSkillHolder();
+
+            Pair<List<String>, Map<String, String>> result = AbilityLoreAppender.getAppendLore(mcRPGPlayer, mockAbility);
+
+            assertNotNull(result);
+            assertTrue(result.getLeft().isEmpty());
+            assertEquals("Maxed Ability", result.getRight().get("ability"));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/builder/item/skill/SkillItemBuilderTest.java
+++ b/src/test/java/us/eunoians/mcrpg/builder/item/skill/SkillItemBuilderTest.java
@@ -1,0 +1,112 @@
+package us.eunoians.mcrpg.builder.item.skill;
+
+import com.diamonddagger590.mccore.parser.Parser;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.MockSkill;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+@DisplayName("SkillItemBuilder")
+class SkillItemBuilderTest extends McRPGBaseTest {
+
+    private MockSkill mockSkill;
+
+    @BeforeEach
+    void setUp() {
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+        mockSkill = spy(MockSkill.class);
+        when(mockSkill.getMaxLevel()).thenReturn(50);
+        when(mockSkill.getLevelUpEquation()).thenReturn(new Parser("100"));
+        skillRegistry.register(mockSkill);
+    }
+
+    @Nested
+    @DisplayName("ItemStack constructor")
+    class ItemStackConstructor {
+
+        @Test
+        @DisplayName("Given an ItemStack with skill holder data, populates all placeholders")
+        void constructor_populatesAllPlaceholders_whenSkillDataPresent(@NotNull McRPGPlayer mcRPGPlayer) {
+            addPlayerToServer(mcRPGPlayer);
+            mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(mockSkill, 5);
+
+            ItemStack itemStack = new ItemStack(Material.DIAMOND_SWORD);
+            SkillItemBuilder builder = new SkillItemBuilder(itemStack, mcRPGPlayer, mockSkill);
+
+            assertNotNull(builder);
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.SKILL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.LEVEL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.CURRENT_EXPERIENCE.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.REQUIRED_EXPERIENCE_TO_LEVEL_UP.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.REMAINING_EXPERIENCE_TO_LEVEL_UP.getKey()));
+        }
+
+        @Test
+        @DisplayName("Given an ItemStack with no skill holder data, placeholders default to zero")
+        void constructor_defaultsToZero_whenNoSkillData(@NotNull McRPGPlayer mcRPGPlayer) {
+            ItemStack itemStack = new ItemStack(Material.DIAMOND_SWORD);
+            SkillItemBuilder builder = new SkillItemBuilder(itemStack, mcRPGPlayer, mockSkill);
+
+            assertNotNull(builder);
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.SKILL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.LEVEL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.CURRENT_EXPERIENCE.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.REQUIRED_EXPERIENCE_TO_LEVEL_UP.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.REMAINING_EXPERIENCE_TO_LEVEL_UP.getKey()));
+        }
+    }
+
+    @Nested
+    @DisplayName("String constructor")
+    class StringConstructor {
+
+        @Test
+        @DisplayName("Given a material string, populates all placeholders")
+        void constructor_populatesAllPlaceholders_whenUsingString(@NotNull McRPGPlayer mcRPGPlayer) {
+            SkillItemBuilder builder = new SkillItemBuilder("DIAMOND_SWORD", mcRPGPlayer, mockSkill);
+
+            assertNotNull(builder);
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.SKILL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.LEVEL.getKey()));
+        }
+    }
+
+    @Nested
+    @DisplayName("from factory methods")
+    class FromFactoryMethods {
+
+        @Test
+        @DisplayName("Given an existing SkillItemBuilder, creates new SkillItemBuilder with placeholders")
+        void from_createsBuilderWithPlaceholders_whenGivenSkillItemBuilder(@NotNull McRPGPlayer mcRPGPlayer) {
+            addPlayerToServer(mcRPGPlayer);
+            mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(mockSkill, 10);
+
+            SkillItemBuilder source = new SkillItemBuilder(new ItemStack(Material.IRON_PICKAXE), mcRPGPlayer, mockSkill);
+            SkillItemBuilder builder = SkillItemBuilder.from(source, mcRPGPlayer, mockSkill);
+
+            assertNotNull(builder);
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.SKILL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.LEVEL.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.CURRENT_EXPERIENCE.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.REQUIRED_EXPERIENCE_TO_LEVEL_UP.getKey()));
+            assertTrue(builder.hasPlaceholder(SkillItemPlaceholderKeys.REMAINING_EXPERIENCE_TO_LEVEL_UP.getKey()));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/availability/AvailabilityWindowCheckerTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/availability/AvailabilityWindowCheckerTest.java
@@ -1,0 +1,211 @@
+package us.eunoians.mcrpg.quest.availability;
+
+import com.diamonddagger590.mccore.util.TimeProvider;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainRegistry;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+import us.eunoians.mcrpg.quest.chain.availability.AvailabilityConfig;
+import us.eunoians.mcrpg.quest.chain.availability.AvailabilityWindowDefinition;
+import us.eunoians.mcrpg.quest.chain.availability.WindowBoundary;
+import us.eunoians.mcrpg.quest.chain.availability.WindowClosePolicy;
+import us.eunoians.mcrpg.quest.definition.QuestDefinition;
+import us.eunoians.mcrpg.quest.definition.QuestDefinitionRegistry;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AvailabilityWindowChecker")
+class AvailabilityWindowCheckerTest extends McRPGBaseTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    private QuestChainRegistry chainRegistry;
+    private QuestDefinitionRegistry definitionRegistry;
+    private AvailabilityWindowChecker checker;
+    private TimeProvider timeProvider;
+
+    @BeforeEach
+    void setUp() {
+        chainRegistry = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.QUEST_CHAIN);
+        definitionRegistry = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.QUEST_DEFINITION);
+
+        timeProvider = McRPG.getInstance().getTimeProvider();
+
+        checker = new AvailabilityWindowChecker(mcRPG, 60);
+    }
+
+    @NotNull
+    private NamespacedKey key(@NotNull String name) {
+        return new NamespacedKey(mcRPG, name);
+    }
+
+    @NotNull
+    private AvailabilityConfig availableWindowConfig(@NotNull ZonedDateTime now) {
+        WindowBoundary from = new WindowBoundary.Fixed(
+                LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth() - 1, 0, 0)
+        );
+        WindowBoundary until = new WindowBoundary.Fixed(
+                LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth() + 1, 23, 59)
+        );
+        AvailabilityWindowDefinition window = new AvailabilityWindowDefinition("test-window", from, until);
+        return new AvailabilityConfig(Map.of("test-window", window), UTC, WindowClosePolicy.EXPIRE_ACTIVE, null);
+    }
+
+    @NotNull
+    private AvailabilityConfig unavailableWindowConfig(@NotNull ZonedDateTime now) {
+        WindowBoundary from = new WindowBoundary.Fixed(
+                LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth() + 2, 0, 0)
+        );
+        WindowBoundary until = new WindowBoundary.Fixed(
+                LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth() + 3, 23, 59)
+        );
+        AvailabilityWindowDefinition window = new AvailabilityWindowDefinition("closed-window", from, until);
+        return new AvailabilityConfig(Map.of("closed-window", window), UTC, WindowClosePolicy.EXPIRE_ACTIVE, null);
+    }
+
+    @NotNull
+    private QuestChainDefinition buildChain(@NotNull NamespacedKey chainKey, @NotNull AvailabilityConfig config) {
+        NamespacedKey sourceKey = key("test-source");
+        NamespacedKey triggerKey = key("test-trigger");
+        NamespacedKey questKey = key("quest-" + chainKey.getKey());
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, List.of(QuestChainStep.simple(questKey)))
+                .availabilityConfig(config)
+                .build();
+    }
+
+    @NotNull
+    private QuestChainDefinition buildChainNoAvailability(@NotNull NamespacedKey chainKey) {
+        NamespacedKey sourceKey = key("test-source");
+        NamespacedKey triggerKey = key("test-trigger");
+        NamespacedKey questKey = key("quest-" + chainKey.getKey());
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, List.of(QuestChainStep.simple(questKey)))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("isChainAvailable")
+    class IsChainAvailable {
+
+        @Test
+        @DisplayName("Given an unregistered chain key, returns false")
+        void isChainAvailable_returnsFalse_whenChainNotRegistered() {
+            NamespacedKey unknownKey = key("nonexistent-chain");
+            when(timeProvider.now()).thenReturn(Instant.now());
+
+            assertFalse(checker.isChainAvailable(unknownKey));
+        }
+
+        @Test
+        @DisplayName("Given a registered chain with no availability config, returns true")
+        void isChainAvailable_returnsTrue_whenNoAvailabilityConfig() {
+            NamespacedKey chainKey = key("no-config-chain");
+            QuestChainDefinition definition = buildChainNoAvailability(chainKey);
+            chainRegistry.register(definition);
+
+            when(timeProvider.now()).thenReturn(Instant.now());
+
+            assertTrue(checker.isChainAvailable(chainKey));
+        }
+
+        @Test
+        @DisplayName("Given a registered chain within its availability window, returns true")
+        void isChainAvailable_returnsTrue_whenWithinWindow() {
+            ZonedDateTime now = ZonedDateTime.of(
+                    LocalDateTime.of(2026, Month.JUNE, 15, 12, 0),
+                    UTC
+            );
+            when(timeProvider.now()).thenReturn(now.toInstant());
+
+            NamespacedKey chainKey = key("available-chain");
+            AvailabilityConfig config = availableWindowConfig(now);
+            QuestChainDefinition definition = buildChain(chainKey, config);
+            chainRegistry.register(definition);
+
+            assertTrue(checker.isChainAvailable(chainKey));
+        }
+
+        @Test
+        @DisplayName("Given a registered chain outside its availability window, returns false")
+        void isChainAvailable_returnsFalse_whenOutsideWindow() {
+            ZonedDateTime now = ZonedDateTime.of(
+                    LocalDateTime.of(2026, Month.JUNE, 15, 12, 0),
+                    UTC
+            );
+            when(timeProvider.now()).thenReturn(now.toInstant());
+
+            NamespacedKey chainKey = key("unavailable-chain");
+            AvailabilityConfig config = unavailableWindowConfig(now);
+            QuestChainDefinition definition = buildChain(chainKey, config);
+            chainRegistry.register(definition);
+
+            assertFalse(checker.isChainAvailable(chainKey));
+        }
+    }
+
+    @Nested
+    @DisplayName("isQuestAvailable")
+    class IsQuestAvailable {
+
+        @Test
+        @DisplayName("Given an unregistered quest key, returns false")
+        void isQuestAvailable_returnsFalse_whenQuestNotRegistered() {
+            NamespacedKey unknownKey = key("nonexistent-quest");
+
+            assertFalse(checker.isQuestAvailable(unknownKey));
+        }
+
+        @Test
+        @DisplayName("Given a registered quest definition, returns true")
+        void isQuestAvailable_returnsTrue_whenQuestRegistered() {
+            NamespacedKey questKey = key("registered-quest");
+            QuestDefinition definition = mock(QuestDefinition.class);
+            when(definition.getQuestKey()).thenReturn(questKey);
+            definitionRegistry.register(definition);
+
+            assertTrue(checker.isQuestAvailable(questKey));
+        }
+    }
+
+    @Nested
+    @DisplayName("Constructor")
+    class ConstructorTests {
+
+        @Test
+        @DisplayName("Constructs without error for valid interval")
+        void constructor_succeeds_withValidInterval() {
+            AvailabilityWindowChecker newChecker = new AvailabilityWindowChecker(mcRPG, 30);
+            assertSame(mcRPG, newChecker.getPlugin());
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlugin")
+    class GetPlugin {
+
+        @Test
+        @DisplayName("Returns the McRPG plugin instance")
+        void getPlugin_returnsMcRPG() {
+            assertSame(mcRPG, checker.getPlugin());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **AvailabilityWindowCheckerTest** (8 tests): Covers `isChainAvailable` (unregistered chain, no availability config, within window, outside window) and `isQuestAvailable` (unregistered quest, registered quest), plus constructor and `getPlugin` accessors.
- **SkillItemBuilderTest** (4 tests): Covers ItemStack constructor with and without skill data, String constructor, and `from()` factory method — verifies all placeholder keys are populated.
- **AbilityLoreAppenderTest** (4 tests): Covers `getAppendLore` for no ability data, non-tierable ability, locked tierable ability, and unlocked tierable at max tier.

## Test plan

- [x] All 16 new tests pass
- [x] Full test suite passes (`./gradlew test` — zero failures)
- [x] Testing audit persona reviewed — one actionable finding fixed (removed unused `@ExtendWith(McRPGPlayerExtension.class)` from `AvailabilityWindowCheckerTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXdeXA6yLKgsLMQGT2Lhcb

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdeXA6yLKgsLMQGT2Lhcb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for ability lore generation, including locked, unlocked, and non-tierable abilities.
  * Added tests verifying skill item creation and placeholder values with and without skill data.
  * Added tests for quest and chain availability across configured time windows and registration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->