### PR TITLE
[Unit Tests] Add processProgress and parseConfig coverage for 5 objective types

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
@@ -1,14 +1,23 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
 import dev.dejvokep.boostedyaml.block.implementation.Section;
+import io.papermc.paper.event.player.PlayerTradeEvent;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
 import org.bukkit.inventory.Recipe;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -321,6 +330,378 @@ public class ObjectiveTypeProcessProgressTest extends McRPGBaseTest {
             ItemStack[] matrix = new ItemStack[]{null, null, null, null, null, null, null, null, null};
             when(inventory.getMatrix()).thenReturn(matrix);
             CraftItemQuestContext context = new CraftItemQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("BucketFillObjectiveType processProgress")
+    class BucketFillProcessProgress {
+
+        private final BucketFillObjectiveType type = new BucketFillObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any bucket")
+        public void processProgress_unconfigured_returnsOne() {
+            PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+            when(event.getItemStack()).thenReturn(new ItemStack(Material.WATER_BUCKET));
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching bucket returns 1")
+        public void processProgress_matchingBucket_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "LAVA_BUCKET"));
+            BucketFillObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+            when(event.getItemStack()).thenReturn(new ItemStack(Material.WATER_BUCKET));
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching bucket returns 0")
+        public void processProgress_nonMatchingBucket_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET"));
+            BucketFillObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+            when(event.getItemStack()).thenReturn(new ItemStack(Material.LAVA_BUCKET));
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("BucketFillObjectiveType parseConfig")
+    class BucketFillParseConfig {
+
+        private final BucketFillObjectiveType type = new BucketFillObjectiveType();
+
+        @Test
+        @DisplayName("section without buckets key accepts any bucket")
+        public void parseConfig_noBucketsKey_acceptsAnyBucket() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+            BucketFillObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+            when(event.getItemStack()).thenReturn(new ItemStack(Material.LAVA_BUCKET));
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("invalid material names are filtered out")
+        public void parseConfig_invalidMaterialFiltered() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "NOT_A_REAL_MATERIAL"));
+            BucketFillObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+            when(event.getItemStack()).thenReturn(new ItemStack(Material.WATER_BUCKET));
+            assertEquals(1, configured.processProgress(mockInstance, new BucketFillQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+            BucketFillObjectiveType configured = type.parseConfig(section);
+            assertEquals(BucketFillObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("BucketEmptyObjectiveType processProgress")
+    class BucketEmptyProcessProgress {
+
+        private final BucketEmptyObjectiveType type = new BucketEmptyObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any bucket")
+        public void processProgress_unconfigured_returnsOne() {
+            PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+            when(event.getBucket()).thenReturn(Material.WATER_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching bucket returns 1")
+        public void processProgress_matchingBucket_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "LAVA_BUCKET"));
+            BucketEmptyObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+            when(event.getBucket()).thenReturn(Material.LAVA_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching bucket returns 0")
+        public void processProgress_nonMatchingBucket_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET"));
+            BucketEmptyObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+            when(event.getBucket()).thenReturn(Material.LAVA_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("BucketEmptyObjectiveType parseConfig")
+    class BucketEmptyParseConfig {
+
+        private final BucketEmptyObjectiveType type = new BucketEmptyObjectiveType();
+
+        @Test
+        @DisplayName("section without buckets key accepts any bucket")
+        public void parseConfig_noBucketsKey_acceptsAnyBucket() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+            BucketEmptyObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+            when(event.getBucket()).thenReturn(Material.LAVA_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("invalid material names are filtered out")
+        public void parseConfig_invalidMaterialFiltered() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("LAVA_BUCKET", "FAKE_BUCKET_XYZ"));
+            BucketEmptyObjectiveType configured = type.parseConfig(section);
+
+            PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+            when(event.getBucket()).thenReturn(Material.LAVA_BUCKET);
+            assertEquals(1, configured.processProgress(mockInstance, new BucketEmptyQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+            BucketEmptyObjectiveType configured = type.parseConfig(section);
+            assertEquals(BucketEmptyObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("ItemPickupObjectiveType processProgress")
+    class ItemPickupProcessProgress {
+
+        private final ItemPickupObjectiveType type = new ItemPickupObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns stack amount")
+        public void processProgress_unconfigured_returnsStackAmount() {
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND, 5));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(5, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns 1 for single item")
+        public void processProgress_unconfigured_returnsSingleAmount() {
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.IRON_INGOT, 1));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns full stack amount for large stack")
+        public void processProgress_unconfigured_returnsLargeStackAmount() {
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.ARROW, 64));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(64, type.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("LaunchProjectileObjectiveType processProgress")
+    class LaunchProjectileProcessProgress {
+
+        private final LaunchProjectileObjectiveType type = new LaunchProjectileObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any projectile")
+        public void processProgress_unconfigured_returnsOne() {
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile entity = mock(Projectile.class);
+            when(entity.getType()).thenReturn(EntityType.ARROW);
+            when(event.getEntity()).thenReturn(entity);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching projectile returns 1")
+        public void processProgress_matchingProjectile_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("ARROW", "SNOWBALL"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile entity = mock(Projectile.class);
+            when(entity.getType()).thenReturn(EntityType.ARROW);
+            when(event.getEntity()).thenReturn(entity);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching projectile returns 0")
+        public void processProgress_nonMatchingProjectile_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("ARROW"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile entity = mock(Projectile.class);
+            when(entity.getType()).thenReturn(EntityType.SNOWBALL);
+            when(event.getEntity()).thenReturn(entity);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("LaunchProjectileObjectiveType parseConfig")
+    class LaunchProjectileParseConfig {
+
+        private final LaunchProjectileObjectiveType type = new LaunchProjectileObjectiveType();
+
+        @Test
+        @DisplayName("section without projectiles key accepts any projectile")
+        public void parseConfig_noProjectilesKey_acceptsAnyProjectile() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(false);
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile entity = mock(Projectile.class);
+            when(entity.getType()).thenReturn(EntityType.TRIDENT);
+            when(event.getEntity()).thenReturn(entity);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("projectile names are parsed case-insensitively")
+        public void parseConfig_caseInsensitive() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("arrow"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile entity = mock(Projectile.class);
+            when(entity.getType()).thenReturn(EntityType.ARROW);
+            when(event.getEntity()).thenReturn(entity);
+            assertEquals(1, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(false);
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+            assertEquals(LaunchProjectileObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("VillagerTradeObjectiveType processProgress")
+    class VillagerTradeProcessProgress {
+
+        private final VillagerTradeObjectiveType type = new VillagerTradeObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns trade result amount")
+        public void processProgress_unconfigured_returnsResultAmount() {
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.EMERALD, 3));
+            when(event.getTrade()).thenReturn(recipe);
+            VillagerTradeQuestContext context = new VillagerTradeQuestContext(event);
+            assertEquals(3, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns 1 for single result item")
+        public void processProgress_unconfigured_returnsSingleAmount() {
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.DIAMOND_CHESTPLATE, 1));
+            when(event.getTrade()).thenReturn(recipe);
+            VillagerTradeQuestContext context = new VillagerTradeQuestContext(event);
             assertEquals(1, type.processProgress(mockInstance, context));
         }
     }


### PR DESCRIPTION
## Summary

- Adds `processProgress` and `parseConfig` tests for **BucketFillObjectiveType**, **BucketEmptyObjectiveType**, **ItemPickupObjectiveType**, **LaunchProjectileObjectiveType**, and **VillagerTradeObjectiveType**
- These 5 types previously only had `canProcess`, `getKey`, and `getExpansionKey` coverage (~17% line coverage each)
- All new tests follow the established `@Nested` class pattern in `ObjectiveTypeProcessProgressTest.java`

## What's covered

| Objective Type | processProgress tests | parseConfig tests |
|---|---|---|
| BucketFillObjectiveType | wrong context, unconfigured, matching bucket, non-matching bucket | missing key, invalid material filtering, key preservation |
| BucketEmptyObjectiveType | wrong context, unconfigured, matching bucket, non-matching bucket | missing key, invalid material filtering, key preservation |
| ItemPickupObjectiveType | wrong context, single item, multi-item stack, large stack (64) | — |
| LaunchProjectileObjectiveType | wrong context, unconfigured, matching projectile, non-matching projectile | missing key, case-insensitive parsing, key preservation |
| VillagerTradeObjectiveType | wrong context, single result, multi-result trade | — |

**27 new test methods** total. Full test suite passes (`./gradlew test` — zero failures).

## Test plan

- [x] All new tests pass individually
- [x] Full test suite passes with zero regressions
- [x] Tests follow `ObjectiveTypeProcessProgressTest` naming and structure conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7dHuvmedF567hnoB7E1Ks

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7dHuvmedF567hnoB7E1Ks)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for bucket filling and emptying, item pickup, projectile launching, and villager trading objectives.
  * Verified progress handling for matching, non-matching, missing, and invalid configurations.
  * Confirmed behavior across different event contexts and case variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->