### PR TITLE
[Unit Tests] Objective type parseConfig and processProgress coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BreedAnimalObjectiveTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BreedAnimalObjectiveTypeTest.java
@@ -1,54 +1,177 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import com.diamonddagger590.mccore.util.item.CustomEntityWrapper;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityBreedEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
 import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@DisplayName("BreedAnimalObjectiveType")
 public class BreedAnimalObjectiveTypeTest extends McRPGBaseTest {
 
     private BreedAnimalObjectiveType type;
+    private final QuestObjectiveInstance mockInstance = mock(QuestObjectiveInstance.class);
 
     @BeforeEach
     public void setup() {
         type = new BreedAnimalObjectiveType();
     }
 
-    @DisplayName("Given a BreedAnimalQuestContext, when calling canProcess, then it returns true")
-    @Test
-    public void canProcess_returnsTrue_forBreedAnimalContext() {
-        org.bukkit.event.entity.EntityBreedEvent mockEvent =
-                org.mockito.Mockito.mock(org.bukkit.event.entity.EntityBreedEvent.class);
-        LivingEntity mockEntity = org.mockito.Mockito.mock(LivingEntity.class);
-        org.mockito.Mockito.when(mockEvent.getEntity()).thenReturn(mockEntity);
-        BreedAnimalQuestContext context = new BreedAnimalQuestContext(mockEvent);
-        assertTrue(type.canProcess(context));
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for BreedAnimalQuestContext")
+        public void canProcess_returnsTrue_forBreedAnimalContext() {
+            EntityBreedEvent mockEvent = mock(EntityBreedEvent.class);
+            LivingEntity mockEntity = mock(LivingEntity.class);
+            when(mockEvent.getEntity()).thenReturn(mockEntity);
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(mockEvent);
+            assertTrue(type.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic context")
+        public void canProcess_returnsFalse_forOtherContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(type.canProcess(context));
+        }
     }
 
-    @DisplayName("Given a non-BreedAnimal context, when calling canProcess, then it returns false")
-    @Test
-    public void canProcess_returnsFalse_forOtherContext() {
-        QuestObjectiveProgressContext context = org.mockito.Mockito.mock(QuestObjectiveProgressContext.class);
-        assertFalse(type.canProcess(context));
+    @Nested
+    @DisplayName("identity")
+    class Identity {
+
+        @Test
+        @DisplayName("key returns breed_animal")
+        public void getKey_returnsBreedAnimalKey() {
+            assertEquals(BreedAnimalObjectiveType.KEY, type.getKey());
+        }
+
+        @Test
+        @DisplayName("expansion key is McRPGExpansion")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(type.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+        }
     }
 
-    @DisplayName("Given the type, when calling getKey, then it returns the breed_animal key")
-    @Test
-    public void getKey_returnsBreedAnimalKey() {
-        assertEquals(BreedAnimalObjectiveType.KEY, type.getKey());
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("returns a new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            BreedAnimalObjectiveType parsed = type.parseConfig(section);
+            assertNotSame(type, parsed);
+        }
+
+        @Test
+        @DisplayName("no entities key produces empty filter")
+        public void parseConfig_noEntitiesKey_producesEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            BreedAnimalObjectiveType parsed = type.parseConfig(section);
+
+            EntityBreedEvent event = createMockBreedEvent(EntityType.COW);
+            assertEquals(1, parsed.processProgress(mockInstance, new BreedAnimalQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("entities key with entries produces filtering type")
+        public void parseConfig_withEntities_producesFilteringType() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW"));
+            BreedAnimalObjectiveType parsed = type.parseConfig(section);
+
+            EntityBreedEvent matchEvent = createMockBreedEvent(EntityType.COW);
+            assertEquals(1, parsed.processProgress(mockInstance, new BreedAnimalQuestContext(matchEvent)));
+
+            EntityBreedEvent noMatchEvent = createMockBreedEvent(EntityType.PIG);
+            assertEquals(0, parsed.processProgress(mockInstance, new BreedAnimalQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            BreedAnimalObjectiveType parsed = type.parseConfig(section);
+            assertEquals(BreedAnimalObjectiveType.KEY, parsed.getKey());
+        }
     }
 
-    @DisplayName("Given the type, when calling getExpansionKey, then it returns McRPGExpansion key")
-    @Test
-    public void getExpansionKey_returnsMcRPGExpansionKey() {
-        assertTrue(type.getExpansionKey().isPresent());
-        assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+    @Nested
+    @DisplayName("processProgress")
+    class ProcessProgress {
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_returnsZero_forWrongContextType() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured type accepts any entity")
+        public void processProgress_returnsOne_whenNoFilter() {
+            EntityBreedEvent event = createMockBreedEvent(EntityType.SHEEP);
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured type returns 1 for matching entity")
+        public void processProgress_returnsOne_forMatchingEntity() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW", "SHEEP"));
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            EntityBreedEvent event = createMockBreedEvent(EntityType.SHEEP);
+            assertEquals(1, configured.processProgress(mockInstance, new BreedAnimalQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("configured type returns 0 for non-matching entity")
+        public void processProgress_returnsZero_forNonMatchingEntity() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW"));
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            EntityBreedEvent event = createMockBreedEvent(EntityType.PIG);
+            assertEquals(0, configured.processProgress(mockInstance, new BreedAnimalQuestContext(event)));
+        }
+    }
+
+    private EntityBreedEvent createMockBreedEvent(EntityType childType) {
+        EntityBreedEvent event = mock(EntityBreedEvent.class);
+        LivingEntity child = mock(LivingEntity.class);
+        when(child.getType()).thenReturn(childType);
+        when(event.getEntity()).thenReturn(child);
+        return event;
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/EnterBedObjectiveTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/EnterBedObjectiveTypeTest.java
@@ -1,51 +1,147 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
 import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@DisplayName("EnterBedObjectiveType")
 public class EnterBedObjectiveTypeTest extends McRPGBaseTest {
 
     private EnterBedObjectiveType type;
+    private final QuestObjectiveInstance mockInstance = mock(QuestObjectiveInstance.class);
 
     @BeforeEach
     public void setup() {
         type = new EnterBedObjectiveType();
     }
 
-    @DisplayName("Given an EnterBedQuestContext, when calling canProcess, then it returns true")
-    @Test
-    public void canProcess_returnsTrue_forEnterBedContext() {
-        org.bukkit.event.player.PlayerBedEnterEvent mockEvent =
-                org.mockito.Mockito.mock(org.bukkit.event.player.PlayerBedEnterEvent.class);
-        EnterBedQuestContext context = new EnterBedQuestContext(mockEvent);
-        assertTrue(type.canProcess(context));
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for EnterBedQuestContext")
+        public void canProcess_returnsTrue_forEnterBedContext() {
+            PlayerBedEnterEvent mockEvent = mock(PlayerBedEnterEvent.class);
+            EnterBedQuestContext context = new EnterBedQuestContext(mockEvent);
+            assertTrue(type.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic context")
+        public void canProcess_returnsFalse_forOtherContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(type.canProcess(context));
+        }
     }
 
-    @DisplayName("Given a non-EnterBed context, when calling canProcess, then it returns false")
-    @Test
-    public void canProcess_returnsFalse_forOtherContext() {
-        QuestObjectiveProgressContext context = org.mockito.Mockito.mock(QuestObjectiveProgressContext.class);
-        assertFalse(type.canProcess(context));
+    @Nested
+    @DisplayName("identity")
+    class Identity {
+
+        @Test
+        @DisplayName("key returns enter_bed")
+        public void getKey_returnsEnterBedKey() {
+            assertEquals(EnterBedObjectiveType.KEY, type.getKey());
+        }
+
+        @Test
+        @DisplayName("expansion key is McRPGExpansion")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(type.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+        }
     }
 
-    @DisplayName("Given the type, when calling getKey, then it returns the enter_bed key")
-    @Test
-    public void getKey_returnsEnterBedKey() {
-        assertEquals(EnterBedObjectiveType.KEY, type.getKey());
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("returns a new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            EnterBedObjectiveType parsed = type.parseConfig(section);
+            assertNotSame(type, parsed);
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            EnterBedObjectiveType parsed = type.parseConfig(section);
+            assertEquals(EnterBedObjectiveType.KEY, parsed.getKey());
+        }
     }
 
-    @DisplayName("Given the type, when calling getExpansionKey, then it returns McRPGExpansion key")
-    @Test
-    public void getExpansionKey_returnsMcRPGExpansionKey() {
-        assertTrue(type.getExpansionKey().isPresent());
-        assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+    @Nested
+    @DisplayName("processProgress")
+    class ProcessProgress {
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_returnsZero_forWrongContextType() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("BedEnterResult.OK returns 1")
+        public void processProgress_returnsOne_whenResultIsOk() {
+            PlayerBedEnterEvent event = mock(PlayerBedEnterEvent.class);
+            when(event.getBedEnterResult()).thenReturn(PlayerBedEnterEvent.BedEnterResult.OK);
+            EnterBedQuestContext context = new EnterBedQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("BedEnterResult.NOT_POSSIBLE_HERE returns 0")
+        public void processProgress_returnsZero_whenResultIsNotPossibleHere() {
+            PlayerBedEnterEvent event = mock(PlayerBedEnterEvent.class);
+            when(event.getBedEnterResult()).thenReturn(PlayerBedEnterEvent.BedEnterResult.NOT_POSSIBLE_HERE);
+            EnterBedQuestContext context = new EnterBedQuestContext(event);
+            assertEquals(0, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("BedEnterResult.NOT_POSSIBLE_NOW returns 0")
+        public void processProgress_returnsZero_whenResultIsNotPossibleNow() {
+            PlayerBedEnterEvent event = mock(PlayerBedEnterEvent.class);
+            when(event.getBedEnterResult()).thenReturn(PlayerBedEnterEvent.BedEnterResult.NOT_POSSIBLE_NOW);
+            EnterBedQuestContext context = new EnterBedQuestContext(event);
+            assertEquals(0, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("BedEnterResult.TOO_FAR_AWAY returns 0")
+        public void processProgress_returnsZero_whenResultIsTooFarAway() {
+            PlayerBedEnterEvent event = mock(PlayerBedEnterEvent.class);
+            when(event.getBedEnterResult()).thenReturn(PlayerBedEnterEvent.BedEnterResult.TOO_FAR_AWAY);
+            EnterBedQuestContext context = new EnterBedQuestContext(event);
+            assertEquals(0, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("BedEnterResult.NOT_SAFE returns 0")
+        public void processProgress_returnsZero_whenResultIsNotSafe() {
+            PlayerBedEnterEvent event = mock(PlayerBedEnterEvent.class);
+            when(event.getBedEnterResult()).thenReturn(PlayerBedEnterEvent.BedEnterResult.NOT_SAFE);
+            EnterBedQuestContext context = new EnterBedQuestContext(event);
+            assertEquals(0, type.processProgress(mockInstance, context));
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/FertilizeBlockObjectiveTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/FertilizeBlockObjectiveTypeTest.java
@@ -1,51 +1,174 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.block.BlockFertilizeEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
 import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@DisplayName("FertilizeBlockObjectiveType")
 public class FertilizeBlockObjectiveTypeTest extends McRPGBaseTest {
 
     private FertilizeBlockObjectiveType type;
+    private final QuestObjectiveInstance mockInstance = mock(QuestObjectiveInstance.class);
 
     @BeforeEach
     public void setup() {
         type = new FertilizeBlockObjectiveType();
     }
 
-    @DisplayName("Given a FertilizeBlockQuestContext, when calling canProcess, then it returns true")
-    @Test
-    public void canProcess_returnsTrue_forFertilizeBlockContext() {
-        org.bukkit.event.block.BlockFertilizeEvent mockEvent =
-                org.mockito.Mockito.mock(org.bukkit.event.block.BlockFertilizeEvent.class);
-        FertilizeBlockQuestContext context = new FertilizeBlockQuestContext(mockEvent);
-        assertTrue(type.canProcess(context));
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for FertilizeBlockQuestContext")
+        public void canProcess_returnsTrue_forFertilizeBlockContext() {
+            BlockFertilizeEvent mockEvent = mock(BlockFertilizeEvent.class);
+            FertilizeBlockQuestContext context = new FertilizeBlockQuestContext(mockEvent);
+            assertTrue(type.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic context")
+        public void canProcess_returnsFalse_forOtherContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(type.canProcess(context));
+        }
     }
 
-    @DisplayName("Given a non-FertilizeBlock context, when calling canProcess, then it returns false")
-    @Test
-    public void canProcess_returnsFalse_forOtherContext() {
-        QuestObjectiveProgressContext context = org.mockito.Mockito.mock(QuestObjectiveProgressContext.class);
-        assertFalse(type.canProcess(context));
+    @Nested
+    @DisplayName("identity")
+    class Identity {
+
+        @Test
+        @DisplayName("key returns fertilize_block")
+        public void getKey_returnsFertilizeBlockKey() {
+            assertEquals(FertilizeBlockObjectiveType.KEY, type.getKey());
+        }
+
+        @Test
+        @DisplayName("expansion key is McRPGExpansion")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(type.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+        }
     }
 
-    @DisplayName("Given the type, when calling getKey, then it returns the fertilize_block key")
-    @Test
-    public void getKey_returnsFertilizeBlockKey() {
-        assertEquals(FertilizeBlockObjectiveType.KEY, type.getKey());
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("returns a new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            when(section.contains("blocks")).thenReturn(false);
+            FertilizeBlockObjectiveType parsed = type.parseConfig(section);
+            assertNotSame(type, parsed);
+        }
+
+        @Test
+        @DisplayName("no blocks key produces empty filter")
+        public void parseConfig_noBlocksKey_producesEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("blocks")).thenReturn(false);
+            FertilizeBlockObjectiveType parsed = type.parseConfig(section);
+
+            BlockFertilizeEvent event = createMockFertilizeEvent(Material.GRASS_BLOCK);
+            assertEquals(1, parsed.processProgress(mockInstance, new FertilizeBlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("blocks key with entries produces filtering type")
+        public void parseConfig_withBlocks_producesFilteringType() {
+            Section section = mock(Section.class);
+            when(section.contains("blocks")).thenReturn(true);
+            when(section.getStringList("blocks")).thenReturn(List.of("GRASS_BLOCK"));
+            FertilizeBlockObjectiveType parsed = type.parseConfig(section);
+
+            BlockFertilizeEvent matchEvent = createMockFertilizeEvent(Material.GRASS_BLOCK);
+            assertEquals(1, parsed.processProgress(mockInstance, new FertilizeBlockQuestContext(matchEvent)));
+
+            BlockFertilizeEvent noMatchEvent = createMockFertilizeEvent(Material.DIRT);
+            assertEquals(0, parsed.processProgress(mockInstance, new FertilizeBlockQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("blocks")).thenReturn(false);
+            FertilizeBlockObjectiveType parsed = type.parseConfig(section);
+            assertEquals(FertilizeBlockObjectiveType.KEY, parsed.getKey());
+        }
     }
 
-    @DisplayName("Given the type, when calling getExpansionKey, then it returns McRPGExpansion key")
-    @Test
-    public void getExpansionKey_returnsMcRPGExpansionKey() {
-        assertTrue(type.getExpansionKey().isPresent());
-        assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+    @Nested
+    @DisplayName("processProgress")
+    class ProcessProgress {
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_returnsZero_forWrongContextType() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured type accepts any block")
+        public void processProgress_returnsOne_whenNoFilter() {
+            BlockFertilizeEvent event = createMockFertilizeEvent(Material.FARMLAND);
+            FertilizeBlockQuestContext context = new FertilizeBlockQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured type returns 1 for matching block")
+        public void processProgress_returnsOne_forMatchingBlock() {
+            Section section = mock(Section.class);
+            when(section.contains("blocks")).thenReturn(true);
+            when(section.getStringList("blocks")).thenReturn(List.of("GRASS_BLOCK", "FARMLAND"));
+            FertilizeBlockObjectiveType configured = type.parseConfig(section);
+
+            BlockFertilizeEvent event = createMockFertilizeEvent(Material.FARMLAND);
+            assertEquals(1, configured.processProgress(mockInstance, new FertilizeBlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("configured type returns 0 for non-matching block")
+        public void processProgress_returnsZero_forNonMatchingBlock() {
+            Section section = mock(Section.class);
+            when(section.contains("blocks")).thenReturn(true);
+            when(section.getStringList("blocks")).thenReturn(List.of("GRASS_BLOCK"));
+            FertilizeBlockObjectiveType configured = type.parseConfig(section);
+
+            BlockFertilizeEvent event = createMockFertilizeEvent(Material.STONE);
+            assertEquals(0, configured.processProgress(mockInstance, new FertilizeBlockQuestContext(event)));
+        }
+    }
+
+    private BlockFertilizeEvent createMockFertilizeEvent(Material material) {
+        BlockFertilizeEvent event = mock(BlockFertilizeEvent.class);
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(material);
+        when(event.getBlock()).thenReturn(block);
+        return event;
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/GainExperienceObjectiveTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/GainExperienceObjectiveTypeTest.java
@@ -134,5 +134,14 @@ public class GainExperienceObjectiveTypeTest extends McRPGBaseTest {
             GainExperienceQuestContext context = new GainExperienceQuestContext(event);
             assertEquals(1000, type.processProgress(mockInstance, context));
         }
+
+        @Test
+        @DisplayName("returns negative value for negative experience amount")
+        public void processProgress_returnsNegative_forNegativeExperience() {
+            PlayerExpChangeEvent event = mock(PlayerExpChangeEvent.class);
+            when(event.getAmount()).thenReturn(-5);
+            GainExperienceQuestContext context = new GainExperienceQuestContext(event);
+            assertEquals(-5, type.processProgress(mockInstance, context));
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/GainExperienceObjectiveTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/GainExperienceObjectiveTypeTest.java
@@ -1,51 +1,138 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
 import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@DisplayName("GainExperienceObjectiveType")
 public class GainExperienceObjectiveTypeTest extends McRPGBaseTest {
 
     private GainExperienceObjectiveType type;
+    private final QuestObjectiveInstance mockInstance = mock(QuestObjectiveInstance.class);
 
     @BeforeEach
     public void setup() {
         type = new GainExperienceObjectiveType();
     }
 
-    @DisplayName("Given a GainExperienceQuestContext, when calling canProcess, then it returns true")
-    @Test
-    public void canProcess_returnsTrue_forGainExperienceContext() {
-        org.bukkit.event.player.PlayerExpChangeEvent mockEvent =
-                org.mockito.Mockito.mock(org.bukkit.event.player.PlayerExpChangeEvent.class);
-        GainExperienceQuestContext context = new GainExperienceQuestContext(mockEvent);
-        assertTrue(type.canProcess(context));
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for GainExperienceQuestContext")
+        public void canProcess_returnsTrue_forGainExperienceContext() {
+            PlayerExpChangeEvent mockEvent = mock(PlayerExpChangeEvent.class);
+            GainExperienceQuestContext context = new GainExperienceQuestContext(mockEvent);
+            assertTrue(type.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic context")
+        public void canProcess_returnsFalse_forOtherContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(type.canProcess(context));
+        }
     }
 
-    @DisplayName("Given a non-GainExperience context, when calling canProcess, then it returns false")
-    @Test
-    public void canProcess_returnsFalse_forOtherContext() {
-        QuestObjectiveProgressContext context = org.mockito.Mockito.mock(QuestObjectiveProgressContext.class);
-        assertFalse(type.canProcess(context));
+    @Nested
+    @DisplayName("identity")
+    class Identity {
+
+        @Test
+        @DisplayName("key returns gain_experience")
+        public void getKey_returnsGainExperienceKey() {
+            assertEquals(GainExperienceObjectiveType.KEY, type.getKey());
+        }
+
+        @Test
+        @DisplayName("expansion key is McRPGExpansion")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(type.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+        }
     }
 
-    @DisplayName("Given the type, when calling getKey, then it returns the gain_experience key")
-    @Test
-    public void getKey_returnsGainExperienceKey() {
-        assertEquals(GainExperienceObjectiveType.KEY, type.getKey());
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("returns a new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            GainExperienceObjectiveType parsed = type.parseConfig(section);
+            assertNotSame(type, parsed);
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            GainExperienceObjectiveType parsed = type.parseConfig(section);
+            assertEquals(GainExperienceObjectiveType.KEY, parsed.getKey());
+        }
     }
 
-    @DisplayName("Given the type, when calling getExpansionKey, then it returns McRPGExpansion key")
-    @Test
-    public void getExpansionKey_returnsMcRPGExpansionKey() {
-        assertTrue(type.getExpansionKey().isPresent());
-        assertEquals(McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+    @Nested
+    @DisplayName("processProgress")
+    class ProcessProgress {
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_returnsZero_forWrongContextType() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("returns the experience amount from the event")
+        public void processProgress_returnsEventAmount() {
+            PlayerExpChangeEvent event = mock(PlayerExpChangeEvent.class);
+            when(event.getAmount()).thenReturn(15);
+            GainExperienceQuestContext context = new GainExperienceQuestContext(event);
+            assertEquals(15, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 for zero experience gain")
+        public void processProgress_returnsZero_forZeroExperience() {
+            PlayerExpChangeEvent event = mock(PlayerExpChangeEvent.class);
+            when(event.getAmount()).thenReturn(0);
+            GainExperienceQuestContext context = new GainExperienceQuestContext(event);
+            assertEquals(0, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("returns 1 for single experience point")
+        public void processProgress_returnsOne_forSingleExperience() {
+            PlayerExpChangeEvent event = mock(PlayerExpChangeEvent.class);
+            when(event.getAmount()).thenReturn(1);
+            GainExperienceQuestContext context = new GainExperienceQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("returns large amount for large experience gain")
+        public void processProgress_returnsLargeAmount() {
+            PlayerExpChangeEvent event = mock(PlayerExpChangeEvent.class);
+            when(event.getAmount()).thenReturn(1000);
+            GainExperienceQuestContext context = new GainExperienceQuestContext(event);
+            assertEquals(1000, type.processProgress(mockInstance, context));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Expands test coverage for **FertilizeBlockObjectiveType**, **BreedAnimalObjectiveType**, **EnterBedObjectiveType**, and **GainExperienceObjectiveType**
- Each test file previously only covered `canProcess`, `getKey`, and `getExpansionKey` (the stub pattern)
- Now adds `@Nested` groups for `parseConfig` and `processProgress` with full edge-case coverage

## Details

### FertilizeBlockObjectiveType
- `parseConfig`: new instance creation, key preservation, empty filter (no `blocks` key), filtering with `blocks` entries
- `processProgress`: wrong context returns 0, unconfigured accepts any block, configured matches/rejects blocks

### BreedAnimalObjectiveType
- `parseConfig`: new instance creation, key preservation, empty filter (no `entities` key), filtering with `entities` entries
- `processProgress`: wrong context returns 0, unconfigured accepts any entity, configured matches/rejects entities

### EnterBedObjectiveType
- `parseConfig`: new instance creation, key preservation
- `processProgress`: wrong context returns 0, `BedEnterResult.OK` returns 1, all denial results (`NOT_POSSIBLE_HERE`, `NOT_POSSIBLE_NOW`, `TOO_FAR_AWAY`, `NOT_SAFE`) return 0

### GainExperienceObjectiveType
- `parseConfig`: new instance creation, key preservation
- `processProgress`: wrong context returns 0, returns exact experience amount, edge cases for 0/1/1000 experience

## Test plan

- [x] All 5106 tests pass (`./gradlew test` — 0 failures)
- [x] Tests follow CLAUDE.md naming conventions (`@DisplayName`, `action_outcome_whenCondition`, `@Nested` grouping)
- [x] No overlap with open PRs (#351, #342, #336 cover different objective types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CC1YvDcUBPMDgUmG68h1PM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CC1YvDcUBPMDgUmG68h1PM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for animal breeding, bed entry, block fertilization, and experience-gain objectives.
  * Added validation for configuration parsing, objective identity, context handling, progress updates, and event filtering.
  * Added scenarios covering matching and non-matching inputs, valid and invalid bed-entry outcomes, and varied experience amounts.
  * Reorganized tests into clearer, grouped sections for improved readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->