### PR TITLE
[Unit Tests] Expand QuestConfigLoader, QuestTemplateConfigLoader, and QuestTemplateEngine coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/configuration/QuestConfigLoaderBoardMetadataTest.java
+++ b/src/test/java/us/eunoians/mcrpg/configuration/QuestConfigLoaderBoardMetadataTest.java
@@ -1,0 +1,608 @@
+package us.eunoians.mcrpg.configuration;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.TestFileUtils;
+import us.eunoians.mcrpg.quest.board.BoardMetadata;
+import us.eunoians.mcrpg.quest.board.template.condition.ConditionParser;
+import us.eunoians.mcrpg.quest.board.template.condition.TemplateConditionRegistry;
+import us.eunoians.mcrpg.quest.definition.OnStartMessage;
+import us.eunoians.mcrpg.quest.definition.QuestDefinition;
+import us.eunoians.mcrpg.quest.definition.QuestRepeatMode;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveTypeRegistry;
+import us.eunoians.mcrpg.quest.objective.type.builtin.BlockBreakObjectiveType;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
+
+    private QuestConfigLoader loader;
+
+    @BeforeEach
+    public void setup() {
+        TemplateConditionRegistry conditionRegistry = RegistryAccess.registryAccess()
+                .registry(McRPGRegistryKey.TEMPLATE_CONDITION);
+        loader = new QuestConfigLoader(new ConditionParser(conditionRegistry));
+        QuestObjectiveTypeRegistry objReg = RegistryAccess.registryAccess()
+                .registry(McRPGRegistryKey.QUEST_OBJECTIVE_TYPE);
+        if (objReg.get(BlockBreakObjectiveType.KEY).isEmpty()) {
+            objReg.register(new BlockBreakObjectiveType());
+        }
+    }
+
+    @DisplayName("Given board-metadata with all fields, when loading, then BoardMetadata is parsed with correct values")
+    @Test
+    public void boardMetadata_allFields_parsedCorrectly() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_board_meta");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:board_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    board-metadata:\n" +
+                    "      board-eligible: true\n" +
+                    "      supported-rarities:\n" +
+                    "        - \"mcrpg:common\"\n" +
+                    "        - \"mcrpg:rare\"\n" +
+                    "      acceptance-cooldown: \"2h\"\n" +
+                    "      cooldown-scope: \"PLAYER\"\n" +
+                    "      supported-refresh-types:\n" +
+                    "        - \"daily\"\n" +
+                    "        - \"weekly\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "board_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:board_quest"));
+            assertNotNull(def);
+
+            Optional<BoardMetadata> metaOpt = def.getBoardMetadata();
+            assertTrue(metaOpt.isPresent());
+            BoardMetadata meta = metaOpt.get();
+            assertTrue(meta.boardEligible());
+            assertEquals(2, meta.supportedRarities().size());
+            assertTrue(meta.supportedRarities().contains(NamespacedKey.fromString("mcrpg:common")));
+            assertTrue(meta.supportedRarities().contains(NamespacedKey.fromString("mcrpg:rare")));
+            assertEquals(Duration.ofHours(2), meta.acceptanceCooldown());
+            assertEquals("PLAYER", meta.cooldownScope());
+            assertEquals(2, meta.supportedRefreshTypes().size());
+            assertTrue(meta.supportedRefreshTypes().contains("DAILY"));
+            assertTrue(meta.supportedRefreshTypes().contains("WEEKLY"));
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given board-metadata with board-eligible false, when loading, then boardEligible is false")
+    @Test
+    public void boardMetadata_notEligible_parsedCorrectly() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_board_meta_ineligible");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:ineligible_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    board-metadata:\n" +
+                    "      board-eligible: false\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "ineligible_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:ineligible_quest"));
+            assertNotNull(def);
+
+            Optional<BoardMetadata> metaOpt = def.getBoardMetadata();
+            assertTrue(metaOpt.isPresent());
+            assertFalse(metaOpt.get().boardEligible());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given no board-metadata section, when loading, then BoardMetadata is absent")
+    @Test
+    public void boardMetadata_absent_returnsEmpty() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_board_meta_absent");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:no_meta_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "no_meta_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:no_meta_quest"));
+            assertNotNull(def);
+            assertFalse(def.getBoardMetadata().isPresent());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given display section with name, description, objectives, and rewards, when loading, then inline display is populated")
+    @Test
+    public void inlineDisplay_allFields_parsedCorrectly() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_inline_display");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:display_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    display:\n" +
+                    "      name: \"Mining Quest\"\n" +
+                    "      description: \"Mine some blocks\"\n" +
+                    "      objectives:\n" +
+                    "        obj_1: \"Break 10 stone\"\n" +
+                    "        obj_2: \"Break 5 iron ore\"\n" +
+                    "      rewards:\n" +
+                    "        reward_1: \"100 XP\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "display_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:display_quest"));
+            assertNotNull(def);
+
+            Map<String, String> display = def.getInlineDisplay();
+            assertEquals("Mining Quest", display.get("name"));
+            assertEquals("Mine some blocks", display.get("description"));
+            assertEquals("Break 10 stone", display.get("objective.obj_1"));
+            assertEquals("Break 5 iron ore", display.get("objective.obj_2"));
+            assertEquals("100 XP", display.get("reward.reward_1"));
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given no display section, when loading, then inline display is empty")
+    @Test
+    public void inlineDisplay_absent_returnsEmpty() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_no_display");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:no_display_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "no_display_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:no_display_quest"));
+            assertNotNull(def);
+            assertTrue(def.getInlineDisplay().isEmpty());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given on-start-messages with locale key entry, when loading, then locale-backed message is parsed")
+    @Test
+    public void onStartMessages_localeKey_parsedCorrectly() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_on_start_locale");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:start_msg_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    on-start-messages:\n" +
+                    "      welcome:\n" +
+                    "        key: \"quests.mining.start-welcome\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "start_msg_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:start_msg_quest"));
+            assertNotNull(def);
+
+            List<OnStartMessage> messages = def.getOnStartMessages();
+            assertEquals(1, messages.size());
+            OnStartMessage msg = messages.get(0);
+            assertTrue(msg.localeKey().isPresent());
+            assertEquals("quests.mining.start-welcome", msg.localeKey().get());
+            assertTrue(msg.inlineMessages().isEmpty());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given on-start-messages with inline messages, when loading, then inline message is parsed")
+    @Test
+    public void onStartMessages_inlineMessages_parsedCorrectly() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_on_start_inline");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:inline_msg_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    on-start-messages:\n" +
+                    "      hint:\n" +
+                    "        messages:\n" +
+                    "          - \"<gold>Quest started!\"\n" +
+                    "          - \"<gray>Break some blocks.\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "inline_msg_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:inline_msg_quest"));
+            assertNotNull(def);
+
+            List<OnStartMessage> messages = def.getOnStartMessages();
+            assertEquals(1, messages.size());
+            OnStartMessage msg = messages.get(0);
+            assertFalse(msg.localeKey().isPresent());
+            assertEquals(2, msg.inlineMessages().size());
+            assertEquals("<gold>Quest started!", msg.inlineMessages().get(0));
+            assertEquals("<gray>Break some blocks.", msg.inlineMessages().get(1));
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given no on-start-messages section, when loading, then on-start messages list is empty")
+    @Test
+    public void onStartMessages_absent_returnsEmpty() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_on_start_absent");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:no_start_msg_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "no_start_msg_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:no_start_msg_quest"));
+            assertNotNull(def);
+            assertTrue(def.getOnStartMessages().isEmpty());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given on-start-messages entry with neither key nor messages, when loading, then entry is skipped")
+    @Test
+    public void onStartMessages_noKeyOrMessages_skipped() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_on_start_skip");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:skip_msg_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    on-start-messages:\n" +
+                    "      bad_entry:\n" +
+                    "        other-field: \"value\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "skip_msg_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:skip_msg_quest"));
+            assertNotNull(def);
+            assertTrue(def.getOnStartMessages().isEmpty());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given quest-chain-file flag, when loading, then quest file is skipped for definitions")
+    @Test
+    public void chainFileFlag_skipsDefinitions() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_chain_file");
+        try {
+            String yaml = "quest-chain-file: true\n" +
+                    "quests:\n" +
+                    "  mcrpg:chain_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "chain_quest.yml", yaml);
+
+            QuestLoadResult loadResult = loader.loadQuestsFromDirectory(tempDir.toFile());
+            assertTrue(loadResult.definitions().isEmpty(), "Chain files should not produce quest definitions");
+            assertFalse(loadResult.chainFiles().isEmpty(), "Chain file path should be recorded");
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given COOLDOWN_LIMITED repeat mode without cooldown or limit, when loading, then quest still loads with warnings")
+    @Test
+    public void repeatMode_cooldownLimited_missingFields_stillLoads() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_repeat_mode");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:repeat_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    repeat-mode: COOLDOWN_LIMITED\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "repeat_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:repeat_quest"));
+            assertNotNull(def, "Quest with COOLDOWN_LIMITED and missing fields should still load");
+            assertEquals(QuestRepeatMode.COOLDOWN_LIMITED, def.getRepeatMode());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given expiration in days-hours-minutes format, when loading, then expiration duration is correct")
+    @Test
+    public void expiration_combinedFormat_parsedCorrectly() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_expiration");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:expire_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    expiration: \"1d6h\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "expire_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:expire_quest"));
+            assertNotNull(def);
+            assertTrue(def.getExpiration().isPresent());
+            assertEquals(Duration.ofDays(1).plusHours(6), def.getExpiration().get());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given multiple on-start-messages entries mixing locale and inline, when loading, then both are preserved in order")
+    @Test
+    public void onStartMessages_mixedEntries_preservedInOrder() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_on_start_mixed");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:mixed_msg_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    on-start-messages:\n" +
+                    "      locale_entry:\n" +
+                    "        key: \"quests.mining.start\"\n" +
+                    "      inline_entry:\n" +
+                    "        messages:\n" +
+                    "          - \"<gold>Good luck!\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "mixed_msg_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:mixed_msg_quest"));
+            assertNotNull(def);
+
+            List<OnStartMessage> messages = def.getOnStartMessages();
+            assertEquals(2, messages.size());
+            assertTrue(messages.get(0).localeKey().isPresent());
+            assertFalse(messages.get(1).localeKey().isPresent());
+            assertEquals(1, messages.get(1).inlineMessages().size());
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given invalid completion-mode, when loading, then quest is skipped")
+    @Test
+    public void invalidCompletionMode_questSkipped() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_bad_completion");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:bad_mode_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: INVALID_MODE\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "bad_mode_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            assertTrue(result.isEmpty(), "Quest with invalid completion-mode should be skipped");
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given quest with no phases section, when loading, then quest is skipped")
+    @Test
+    public void noPhases_questSkipped() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_no_phases");
+        try {
+            String yaml = "quests:\n" +
+                    "  mcrpg:no_phase_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n";
+            TestFileUtils.writeFile(tempDir, "no_phase_quest.yml", yaml);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            assertTrue(result.isEmpty(), "Quest with no phases should be skipped");
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+
+    @DisplayName("Given duplicate quest key across files, when loading, then first-loaded wins")
+    @Test
+    public void duplicateQuestKey_firstWins() throws IOException {
+        Path tempDir = Files.createTempDirectory("quest_duplicate");
+        try {
+            String yaml1 = "quests:\n" +
+                    "  mcrpg:dup_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    expiration: \"1h\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            String yaml2 = "quests:\n" +
+                    "  mcrpg:dup_quest:\n" +
+                    "    scope: \"mcrpg:single_player\"\n" +
+                    "    expiration: \"2h\"\n" +
+                    "    phases:\n" +
+                    "      phase:\n" +
+                    "        completion-mode: ALL\n" +
+                    "        stages:\n" +
+                    "          stage:\n" +
+                    "            key: \"mcrpg:stage_1\"\n" +
+                    "            objectives:\n" +
+                    "              objective:\n" +
+                    "                key: \"mcrpg:obj_1\"\n" +
+                    "                type: \"mcrpg:block_break\"\n" +
+                    "                required-progress: 10\n";
+            TestFileUtils.writeFile(tempDir, "dup_quest_a.yml", yaml1);
+            TestFileUtils.writeFile(tempDir, "dup_quest_b.yml", yaml2);
+
+            Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
+            assertEquals(1, result.size(), "Duplicate key should only produce one definition");
+        } finally {
+            TestFileUtils.deleteRecursively(tempDir.toFile());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/configuration/QuestConfigLoaderBoardMetadataTest.java
+++ b/src/test/java/us/eunoians/mcrpg/configuration/QuestConfigLoaderBoardMetadataTest.java
@@ -49,7 +49,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given board-metadata with all fields, when loading, then BoardMetadata is parsed with correct values")
     @Test
-    public void boardMetadata_allFields_parsedCorrectly() throws IOException {
+    public void loadQuests_parsesBoardMetadata_whenAllFieldsPresent() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_board_meta");
         try {
             String yaml = "quests:\n" +
@@ -101,7 +101,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given board-metadata with board-eligible false, when loading, then boardEligible is false")
     @Test
-    public void boardMetadata_notEligible_parsedCorrectly() throws IOException {
+    public void loadQuests_parsesBoardEligibleFalse() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_board_meta_ineligible");
         try {
             String yaml = "quests:\n" +
@@ -136,7 +136,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given no board-metadata section, when loading, then BoardMetadata is absent")
     @Test
-    public void boardMetadata_absent_returnsEmpty() throws IOException {
+    public void loadQuests_returnsEmptyBoardMetadata_whenNoSection() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_board_meta_absent");
         try {
             String yaml = "quests:\n" +
@@ -166,7 +166,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given display section with name, description, objectives, and rewards, when loading, then inline display is populated")
     @Test
-    public void inlineDisplay_allFields_parsedCorrectly() throws IOException {
+    public void loadQuests_parsesInlineDisplay_whenAllFieldsPresent() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_inline_display");
         try {
             String yaml = "quests:\n" +
@@ -210,7 +210,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given no display section, when loading, then inline display is empty")
     @Test
-    public void inlineDisplay_absent_returnsEmpty() throws IOException {
+    public void loadQuests_returnsEmptyDisplay_whenNoDisplaySection() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_no_display");
         try {
             String yaml = "quests:\n" +
@@ -240,7 +240,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given on-start-messages with locale key entry, when loading, then locale-backed message is parsed")
     @Test
-    public void onStartMessages_localeKey_parsedCorrectly() throws IOException {
+    public void loadQuests_parsesLocaleKeyMessage_whenOnStartMessagesHasKey() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_on_start_locale");
         try {
             String yaml = "quests:\n" +
@@ -279,7 +279,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given on-start-messages with inline messages, when loading, then inline message is parsed")
     @Test
-    public void onStartMessages_inlineMessages_parsedCorrectly() throws IOException {
+    public void loadQuests_parsesInlineMessages_whenOnStartMessagesHasMessages() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_on_start_inline");
         try {
             String yaml = "quests:\n" +
@@ -321,7 +321,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given no on-start-messages section, when loading, then on-start messages list is empty")
     @Test
-    public void onStartMessages_absent_returnsEmpty() throws IOException {
+    public void loadQuests_returnsEmptyMessages_whenNoOnStartMessagesSection() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_on_start_absent");
         try {
             String yaml = "quests:\n" +
@@ -351,7 +351,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given on-start-messages entry with neither key nor messages, when loading, then entry is skipped")
     @Test
-    public void onStartMessages_noKeyOrMessages_skipped() throws IOException {
+    public void loadQuests_skipsMessage_whenEntryHasNoKeyOrMessages() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_on_start_skip");
         try {
             String yaml = "quests:\n" +
@@ -384,7 +384,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given quest-chain-file flag, when loading, then quest file is skipped for definitions")
     @Test
-    public void chainFileFlag_skipsDefinitions() throws IOException {
+    public void loadQuests_skipsDefinitions_whenChainFileFlagIsTrue() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_chain_file");
         try {
             String yaml = "quest-chain-file: true\n" +
@@ -414,7 +414,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given COOLDOWN_LIMITED repeat mode without cooldown or limit, when loading, then quest still loads with warnings")
     @Test
-    public void repeatMode_cooldownLimited_missingFields_stillLoads() throws IOException {
+    public void loadQuests_loadsQuest_whenCooldownLimitedMissingFields() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_repeat_mode");
         try {
             String yaml = "quests:\n" +
@@ -445,7 +445,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given expiration in days-hours-minutes format, when loading, then expiration duration is correct")
     @Test
-    public void expiration_combinedFormat_parsedCorrectly() throws IOException {
+    public void loadQuests_parsesExpiration_whenCombinedDaysHoursFormat() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_expiration");
         try {
             String yaml = "quests:\n" +
@@ -477,7 +477,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given multiple on-start-messages entries mixing locale and inline, when loading, then both are preserved in order")
     @Test
-    public void onStartMessages_mixedEntries_preservedInOrder() throws IOException {
+    public void loadQuests_preservesMessageOrder_whenMixedLocaleAndInlineEntries() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_on_start_mixed");
         try {
             String yaml = "quests:\n" +
@@ -518,7 +518,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given invalid completion-mode, when loading, then quest is skipped")
     @Test
-    public void invalidCompletionMode_questSkipped() throws IOException {
+    public void loadQuests_skipsQuest_whenInvalidCompletionMode() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_bad_completion");
         try {
             String yaml = "quests:\n" +
@@ -546,7 +546,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given quest with no phases section, when loading, then quest is skipped")
     @Test
-    public void noPhases_questSkipped() throws IOException {
+    public void loadQuests_skipsQuest_whenNoPhasesSection() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_no_phases");
         try {
             String yaml = "quests:\n" +
@@ -563,7 +563,7 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
     @DisplayName("Given duplicate quest key across files, when loading, then first-loaded wins")
     @Test
-    public void duplicateQuestKey_firstWins() throws IOException {
+    public void loadQuests_keepsOneDefinition_whenDuplicateQuestKey() throws IOException {
         Path tempDir = Files.createTempDirectory("quest_duplicate");
         try {
             String yaml1 = "quests:\n" +
@@ -601,6 +601,12 @@ public class QuestConfigLoaderBoardMetadataTest extends McRPGBaseTest {
 
             Map<NamespacedKey, QuestDefinition> result = loader.loadQuestsFromDirectory(tempDir.toFile()).definitions();
             assertEquals(1, result.size(), "Duplicate key should only produce one definition");
+            QuestDefinition def = result.get(NamespacedKey.fromString("mcrpg:dup_quest"));
+            assertNotNull(def);
+            assertTrue(def.getExpiration().isPresent(), "Surviving definition should retain its expiration");
+            Duration expiration = def.getExpiration().get();
+            assertTrue(expiration.equals(Duration.ofHours(1)) || expiration.equals(Duration.ofHours(2)),
+                    "Surviving definition should have expiration from one of the source files, got: " + expiration);
         } finally {
             TestFileUtils.deleteRecursively(tempDir.toFile());
         }

--- a/src/test/java/us/eunoians/mcrpg/configuration/QuestTemplateConfigLoaderExtendedTest.java
+++ b/src/test/java/us/eunoians/mcrpg/configuration/QuestTemplateConfigLoaderExtendedTest.java
@@ -9,11 +9,11 @@ import us.eunoians.mcrpg.quest.board.template.ObjectiveSelectionConfig;
 import us.eunoians.mcrpg.quest.board.template.QuestTemplate;
 import us.eunoians.mcrpg.quest.board.template.TemplateRewardDefinition;
 import us.eunoians.mcrpg.quest.board.template.TemplateStageDefinition;
+import us.eunoians.mcrpg.TestFileUtils;
 import us.eunoians.mcrpg.quest.board.template.condition.ConditionParser;
 import us.eunoians.mcrpg.quest.board.template.condition.TemplateConditionRegistry;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -38,8 +38,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given objective-selection config with WEIGHTED_RANDOM mode, when loading, then ObjectiveSelectionConfig is parsed")
     @Test
-    void objectiveSelection_weightedRandom_parsed() throws IOException {
-        writeYaml("weighted.yml", """
+    void loadTemplates_parsesObjectiveSelection_whenWeightedRandomMode() throws IOException {
+        TestFileUtils.writeFile(tempDir,"weighted.yml", """
                 quest-templates:
                   mcrpg:weighted_template:
                     display-name-route: "quests.templates.weighted.display-name"
@@ -85,8 +85,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given stage without objective-selection, when loading, then ObjectiveSelectionConfig is absent")
     @Test
-    void objectiveSelection_absent_returnsEmpty() throws IOException {
-        writeYaml("no_sel.yml", """
+    void loadTemplates_returnsEmptySelection_whenNoObjectiveSelectionSection() throws IOException {
+        TestFileUtils.writeFile(tempDir,"no_sel.yml", """
                 quest-templates:
                   mcrpg:no_sel_template:
                     display-name-route: "quests.templates.no-sel.display-name"
@@ -114,8 +114,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with rewards section, when loading, then reward definitions are parsed")
     @Test
-    void rewards_parsed() throws IOException {
-        writeYaml("rewards.yml", """
+    void loadTemplates_parsesRewards_whenRewardsSectionPresent() throws IOException {
+        TestFileUtils.writeFile(tempDir,"rewards.yml", """
                 quest-templates:
                   mcrpg:reward_template:
                     display-name-route: "quests.templates.reward.display-name"
@@ -159,8 +159,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with no rewards section, when loading, then rewards list is empty")
     @Test
-    void rewards_absent_returnsEmpty() throws IOException {
-        writeYaml("no_rewards.yml", """
+    void loadTemplates_returnsEmptyRewards_whenNoRewardsSection() throws IOException {
+        TestFileUtils.writeFile(tempDir,"no_rewards.yml", """
                 quest-templates:
                   mcrpg:no_reward_template:
                     display-name-route: "quests.templates.no-reward.display-name"
@@ -186,8 +186,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with display section, when loading, then inline display is populated")
     @Test
-    void inlineDisplay_parsed() throws IOException {
-        writeYaml("display.yml", """
+    void loadTemplates_parsesInlineDisplay_whenDisplaySectionPresent() throws IOException {
+        TestFileUtils.writeFile(tempDir,"display.yml", """
                 quest-templates:
                   mcrpg:display_template:
                     display-name-route: "quests.templates.display.display-name"
@@ -222,8 +222,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given expression referencing undeclared variable, when loading, then template is skipped")
     @Test
-    void undeclaredVariable_inRequiredProgress_templateSkipped() throws IOException {
-        writeYaml("undeclared.yml", """
+    void loadTemplates_skipsTemplate_whenUndeclaredVariableInProgress() throws IOException {
+        TestFileUtils.writeFile(tempDir,"undeclared.yml", """
                 quest-templates:
                   mcrpg:undeclared_template:
                     display-name-route: "quests.templates.undeclared.display-name"
@@ -253,8 +253,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given expression with invalid syntax, when loading, then template is skipped")
     @Test
-    void invalidExpression_templateSkipped() throws IOException {
-        writeYaml("bad_expr.yml", """
+    void loadTemplates_skipsTemplate_whenInvalidExpressionSyntax() throws IOException {
+        TestFileUtils.writeFile(tempDir,"bad_expr.yml", """
                 quest-templates:
                   mcrpg:bad_expr_template:
                     display-name-route: "quests.templates.bad-expr.display-name"
@@ -284,8 +284,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with reward expression referencing undeclared variable, when loading, then template is skipped")
     @Test
-    void undeclaredVariable_inReward_templateSkipped() throws IOException {
-        writeYaml("reward_undeclared.yml", """
+    void loadTemplates_skipsTemplate_whenUndeclaredVariableInReward() throws IOException {
+        TestFileUtils.writeFile(tempDir,"reward_undeclared.yml", """
                 quest-templates:
                   mcrpg:reward_undeclared:
                     display-name-route: "quests.templates.reward-undeclared.display-name"
@@ -319,8 +319,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with pool variable in objective config, when loading, then config map preserves raw string")
     @Test
-    void objectiveConfig_poolVariableReference_preserved() throws IOException {
-        writeYaml("pool_config.yml", """
+    void loadTemplates_preservesPoolReference_whenPoolVariableInConfig() throws IOException {
+        TestFileUtils.writeFile(tempDir,"pool_config.yml", """
                 quest-templates:
                   mcrpg:pool_config_template:
                     display-name-route: "quests.templates.pool-config.display-name"
@@ -365,8 +365,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with no phases section, when loading, then template is skipped")
     @Test
-    void noPhases_templateSkipped() throws IOException {
-        writeYaml("no_phases.yml", """
+    void loadTemplates_skipsTemplate_whenNoPhasesSection() throws IOException {
+        TestFileUtils.writeFile(tempDir,"no_phases.yml", """
                 quest-templates:
                   mcrpg:no_phases_template:
                     display-name-route: "quests.templates.no-phases.display-name"
@@ -381,8 +381,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with empty objectives in a stage, when loading, then template is skipped")
     @Test
-    void emptyObjectives_templateSkipped() throws IOException {
-        writeYaml("empty_obj.yml", """
+    void loadTemplates_skipsTemplate_whenEmptyObjectives() throws IOException {
+        TestFileUtils.writeFile(tempDir,"empty_obj.yml", """
                 quest-templates:
                   mcrpg:empty_obj_template:
                     display-name-route: "quests.templates.empty-obj.display-name"
@@ -403,8 +403,8 @@ class QuestTemplateConfigLoaderExtendedTest {
 
     @DisplayName("Given template with difficulty variable in expression, when loading, then expression validates successfully")
     @Test
-    void difficultyBuiltinVariable_expressionValid() throws IOException {
-        writeYaml("difficulty.yml", """
+    void loadTemplates_loadsTemplate_whenDifficultyBuiltinVariableUsed() throws IOException {
+        TestFileUtils.writeFile(tempDir,"difficulty.yml", """
                 quest-templates:
                   mcrpg:difficulty_template:
                     display-name-route: "quests.templates.difficulty.display-name"
@@ -427,7 +427,4 @@ class QuestTemplateConfigLoaderExtendedTest {
         assertNotNull(template, "Template using built-in 'difficulty' variable should load successfully");
     }
 
-    private void writeYaml(String fileName, String content) throws IOException {
-        Files.writeString(tempDir.resolve(fileName), content);
-    }
 }

--- a/src/test/java/us/eunoians/mcrpg/configuration/QuestTemplateConfigLoaderExtendedTest.java
+++ b/src/test/java/us/eunoians/mcrpg/configuration/QuestTemplateConfigLoaderExtendedTest.java
@@ -1,0 +1,433 @@
+package us.eunoians.mcrpg.configuration;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import us.eunoians.mcrpg.quest.board.template.ObjectiveSelectionConfig;
+import us.eunoians.mcrpg.quest.board.template.QuestTemplate;
+import us.eunoians.mcrpg.quest.board.template.TemplateRewardDefinition;
+import us.eunoians.mcrpg.quest.board.template.TemplateStageDefinition;
+import us.eunoians.mcrpg.quest.board.template.condition.ConditionParser;
+import us.eunoians.mcrpg.quest.board.template.condition.TemplateConditionRegistry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuestTemplateConfigLoaderExtendedTest {
+
+    private QuestTemplateConfigLoader loader;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        loader = new QuestTemplateConfigLoader(Logger.getLogger("TestLoader"), new ConditionParser(new TemplateConditionRegistry()));
+    }
+
+    @DisplayName("Given objective-selection config with WEIGHTED_RANDOM mode, when loading, then ObjectiveSelectionConfig is parsed")
+    @Test
+    void objectiveSelection_weightedRandom_parsed() throws IOException {
+        writeYaml("weighted.yml", """
+                quest-templates:
+                  mcrpg:weighted_template:
+                    display-name-route: "quests.templates.weighted.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objective-selection:
+                              mode: WEIGHTED_RANDOM
+                              min-count: 2
+                              max-count: 4
+                            objectives:
+                              break-stone:
+                                type: mcrpg:block_break
+                                required-progress: 10
+                                weight: 5
+                              break-dirt:
+                                type: mcrpg:block_break
+                                required-progress: 20
+                                weight: 3
+                              break-iron:
+                                type: mcrpg:block_break
+                                required-progress: 5
+                                weight: 2
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:weighted_template"));
+        assertNotNull(template);
+
+        TemplateStageDefinition stage = template.getPhases().get(0).stages().get(0);
+        Optional<ObjectiveSelectionConfig> selOpt = stage.getObjectiveSelection();
+        assertTrue(selOpt.isPresent());
+        ObjectiveSelectionConfig sel = selOpt.get();
+        assertEquals(ObjectiveSelectionConfig.ObjectiveSelectionMode.WEIGHTED_RANDOM, sel.mode());
+        assertEquals(2, sel.minCount());
+        assertEquals(4, sel.maxCount());
+    }
+
+    @DisplayName("Given stage without objective-selection, when loading, then ObjectiveSelectionConfig is absent")
+    @Test
+    void objectiveSelection_absent_returnsEmpty() throws IOException {
+        writeYaml("no_sel.yml", """
+                quest-templates:
+                  mcrpg:no_sel_template:
+                    display-name-route: "quests.templates.no-sel.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: 10
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:no_sel_template"));
+        assertNotNull(template);
+
+        TemplateStageDefinition stage = template.getPhases().get(0).stages().get(0);
+        assertFalse(stage.getObjectiveSelection().isPresent());
+    }
+
+    @DisplayName("Given template with rewards section, when loading, then reward definitions are parsed")
+    @Test
+    void rewards_parsed() throws IOException {
+        writeYaml("rewards.yml", """
+                quest-templates:
+                  mcrpg:reward_template:
+                    display-name-route: "quests.templates.reward.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    rewards:
+                      xp_reward:
+                        type: mcrpg:experience
+                        amount: "block_count * 10"
+                      cmd_reward:
+                        type: mcrpg:command
+                        command: "give {player} diamond 1"
+                    variables:
+                      block_count:
+                        type: RANGE
+                        base:
+                          min: 10
+                          max: 50
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: "block_count"
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:reward_template"));
+        assertNotNull(template);
+
+        assertEquals(2, template.getRewards().size());
+        TemplateRewardDefinition xpReward = template.getRewards().get(0);
+        assertEquals(NamespacedKey.fromString("mcrpg:experience"), xpReward.typeKey());
+        assertEquals("xp_reward", xpReward.label());
+        assertEquals("block_count * 10", xpReward.config().get("amount"));
+    }
+
+    @DisplayName("Given template with no rewards section, when loading, then rewards list is empty")
+    @Test
+    void rewards_absent_returnsEmpty() throws IOException {
+        writeYaml("no_rewards.yml", """
+                quest-templates:
+                  mcrpg:no_reward_template:
+                    display-name-route: "quests.templates.no-reward.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: 10
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:no_reward_template"));
+        assertNotNull(template);
+        assertTrue(template.getRewards().isEmpty());
+    }
+
+    @DisplayName("Given template with display section, when loading, then inline display is populated")
+    @Test
+    void inlineDisplay_parsed() throws IOException {
+        writeYaml("display.yml", """
+                quest-templates:
+                  mcrpg:display_template:
+                    display-name-route: "quests.templates.display.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    display:
+                      name: "Mining Quest"
+                      description: "Mine some blocks"
+                      objectives:
+                        break_blocks: "Break stones"
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: 10
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:display_template"));
+        assertNotNull(template);
+
+        Map<String, String> display = template.getInlineDisplay();
+        assertEquals("Mining Quest", display.get("name"));
+        assertEquals("Mine some blocks", display.get("description"));
+        assertEquals("Break stones", display.get("objective.break_blocks"));
+    }
+
+    @DisplayName("Given expression referencing undeclared variable, when loading, then template is skipped")
+    @Test
+    void undeclaredVariable_inRequiredProgress_templateSkipped() throws IOException {
+        writeYaml("undeclared.yml", """
+                quest-templates:
+                  mcrpg:undeclared_template:
+                    display-name-route: "quests.templates.undeclared.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    variables:
+                      block_count:
+                        type: RANGE
+                        base:
+                          min: 10
+                          max: 50
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: "unknown_var * 10"
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        assertTrue(result.isEmpty(), "Template with undeclared variable in expression should be skipped");
+    }
+
+    @DisplayName("Given expression with invalid syntax, when loading, then template is skipped")
+    @Test
+    void invalidExpression_templateSkipped() throws IOException {
+        writeYaml("bad_expr.yml", """
+                quest-templates:
+                  mcrpg:bad_expr_template:
+                    display-name-route: "quests.templates.bad-expr.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    variables:
+                      count:
+                        type: RANGE
+                        base:
+                          min: 10
+                          max: 50
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: "count * * 10"
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        assertTrue(result.isEmpty(), "Template with invalid expression syntax should be skipped");
+    }
+
+    @DisplayName("Given template with reward expression referencing undeclared variable, when loading, then template is skipped")
+    @Test
+    void undeclaredVariable_inReward_templateSkipped() throws IOException {
+        writeYaml("reward_undeclared.yml", """
+                quest-templates:
+                  mcrpg:reward_undeclared:
+                    display-name-route: "quests.templates.reward-undeclared.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    variables:
+                      block_count:
+                        type: RANGE
+                        base:
+                          min: 10
+                          max: 50
+                    rewards:
+                      xp_reward:
+                        type: mcrpg:experience
+                        amount: "block_count + missing_var"
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: "block_count"
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        assertTrue(result.isEmpty(), "Template with undeclared variable in reward expression should be skipped");
+    }
+
+    @DisplayName("Given template with pool variable in objective config, when loading, then config map preserves raw string")
+    @Test
+    void objectiveConfig_poolVariableReference_preserved() throws IOException {
+        writeYaml("pool_config.yml", """
+                quest-templates:
+                  mcrpg:pool_config_template:
+                    display-name-route: "quests.templates.pool-config.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    variables:
+                      block_type:
+                        type: POOL
+                        pools:
+                          common_stones:
+                            difficulty: 1.0
+                            weight:
+                              COMMON: 100
+                            values: [STONE, GRANITE]
+                          rare_ores:
+                            difficulty: 3.0
+                            weight:
+                              COMMON: 100
+                            values: [DIAMOND_ORE]
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: 10
+                                config:
+                                  material: "block_type"
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:pool_config_template"));
+        assertNotNull(template);
+
+        var objectives = template.getPhases().get(0).stages().get(0).objectives();
+        assertEquals(1, objectives.size());
+        assertEquals("block_type", objectives.get(0).config().get("material"));
+    }
+
+    @DisplayName("Given template with no phases section, when loading, then template is skipped")
+    @Test
+    void noPhases_templateSkipped() throws IOException {
+        writeYaml("no_phases.yml", """
+                quest-templates:
+                  mcrpg:no_phases_template:
+                    display-name-route: "quests.templates.no-phases.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        assertTrue(result.isEmpty(), "Template with no phases should be skipped");
+    }
+
+    @DisplayName("Given template with empty objectives in a stage, when loading, then template is skipped")
+    @Test
+    void emptyObjectives_templateSkipped() throws IOException {
+        writeYaml("empty_obj.yml", """
+                quest-templates:
+                  mcrpg:empty_obj_template:
+                    display-name-route: "quests.templates.empty-obj.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        assertTrue(result.isEmpty(), "Template with empty objectives should be skipped");
+    }
+
+    @DisplayName("Given template with difficulty variable in expression, when loading, then expression validates successfully")
+    @Test
+    void difficultyBuiltinVariable_expressionValid() throws IOException {
+        writeYaml("difficulty.yml", """
+                quest-templates:
+                  mcrpg:difficulty_template:
+                    display-name-route: "quests.templates.difficulty.display-name"
+                    board-eligible: true
+                    scope: mcrpg:single_player
+                    supported-rarities: [COMMON]
+                    phases:
+                      phase:
+                        completion-mode: ALL
+                        stages:
+                          stage:
+                            objectives:
+                              break-blocks:
+                                type: mcrpg:block_break
+                                required-progress: "difficulty * 50"
+                """);
+
+        Map<NamespacedKey, QuestTemplate> result = loader.loadTemplatesFromDirectory(tempDir.toFile());
+        QuestTemplate template = result.get(NamespacedKey.fromString("mcrpg:difficulty_template"));
+        assertNotNull(template, "Template using built-in 'difficulty' variable should load successfully");
+    }
+
+    private void writeYaml(String fileName, String content) throws IOException {
+        Files.writeString(tempDir.resolve(fileName), content);
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/QuestTemplateEngineEdgeCaseTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/QuestTemplateEngineEdgeCaseTest.java
@@ -1,0 +1,331 @@
+package us.eunoians.mcrpg.quest.board.template;
+
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.quest.board.rarity.QuestRarity;
+import us.eunoians.mcrpg.quest.board.rarity.QuestRarityRegistry;
+import us.eunoians.mcrpg.quest.board.template.condition.TemplateCondition;
+import us.eunoians.mcrpg.quest.board.template.condition.TemplateConditionRegistry;
+import us.eunoians.mcrpg.quest.board.template.variable.RangeVariable;
+import us.eunoians.mcrpg.quest.board.template.variable.TemplateVariable;
+import us.eunoians.mcrpg.quest.definition.PhaseCompletionMode;
+import us.eunoians.mcrpg.quest.definition.QuestDefinition;
+import us.eunoians.mcrpg.quest.definition.QuestObjectiveDefinition;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveType;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveTypeRegistry;
+import us.eunoians.mcrpg.quest.reward.QuestRewardType;
+import us.eunoians.mcrpg.quest.reward.QuestRewardTypeRegistry;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QuestTemplateEngineEdgeCaseTest {
+
+    private static final NamespacedKey COMMON = NamespacedKey.fromString("mcrpg:common");
+    private static final NamespacedKey EXPANSION_KEY = NamespacedKey.fromString("mcrpg:mcrpg");
+    private static final NamespacedKey TEMPLATE_KEY = NamespacedKey.fromString("mcrpg:edge_test");
+    private static final NamespacedKey OBJECTIVE_TYPE_KEY = NamespacedKey.fromString("mcrpg:block_break");
+    private static final NamespacedKey REWARD_TYPE_KEY = NamespacedKey.fromString("mcrpg:experience");
+    private static final NamespacedKey SCOPE_KEY = NamespacedKey.fromString("mcrpg:single_player");
+
+    private QuestRarityRegistry rarityRegistry;
+    private QuestObjectiveTypeRegistry objectiveTypeRegistry;
+    private QuestRewardTypeRegistry rewardTypeRegistry;
+    private QuestTemplateEngine engine;
+
+    @BeforeEach
+    void setUp() {
+        rarityRegistry = mock(QuestRarityRegistry.class);
+        objectiveTypeRegistry = mock(QuestObjectiveTypeRegistry.class);
+        rewardTypeRegistry = mock(QuestRewardTypeRegistry.class);
+
+        QuestObjectiveType mockObjectiveType = mock(QuestObjectiveType.class);
+        when(mockObjectiveType.getKey()).thenReturn(OBJECTIVE_TYPE_KEY);
+        when(mockObjectiveType.parseConfig(any())).thenReturn(mockObjectiveType);
+        when(objectiveTypeRegistry.get(OBJECTIVE_TYPE_KEY)).thenReturn(Optional.of(mockObjectiveType));
+
+        QuestRewardType mockRewardType = mock(QuestRewardType.class);
+        when(mockRewardType.getKey()).thenReturn(REWARD_TYPE_KEY);
+        when(mockRewardType.fromSerializedConfig(any())).thenAnswer(invocation -> {
+            Map<String, Object> config = invocation.getArgument(0);
+            QuestRewardType configured = mock(QuestRewardType.class);
+            when(configured.getKey()).thenReturn(REWARD_TYPE_KEY);
+            when(configured.serializeConfig()).thenReturn(new LinkedHashMap<>(config));
+            when(configured.withLocalizationRoute(any())).thenReturn(configured);
+            return configured;
+        });
+        when(rewardTypeRegistry.get(REWARD_TYPE_KEY)).thenReturn(Optional.of(mockRewardType));
+
+        when(rarityRegistry.get(COMMON)).thenReturn(Optional.of(
+                new QuestRarity(COMMON, 10, 1.0, 1.0, EXPANSION_KEY)));
+
+        McRPG mockPlugin = mock(McRPG.class);
+        when(mockPlugin.getLogger()).thenReturn(Logger.getLogger("QuestTemplateEngineEdgeCaseTest"));
+        var conditionRegistry = mock(TemplateConditionRegistry.class);
+        var codec = new GeneratedQuestDefinitionCodec(objectiveTypeRegistry, rewardTypeRegistry, conditionRegistry);
+        engine = new QuestTemplateEngine(rarityRegistry, objectiveTypeRegistry, rewardTypeRegistry, mockPlugin, new WeightedObjectiveSelector(), codec);
+    }
+
+    @Test
+    @DisplayName("Given template with only range variables (no pools), when generating, then difficulty defaults to 1.0 * rarity")
+    void resolveVariables_noPoolVariables_difficultyDefaultsToRarity() {
+        RangeVariable count = new RangeVariable("count", 10, 20);
+        Map<String, TemplateVariable> variables = new LinkedHashMap<>();
+        variables.put("count", count);
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "count", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), variables, List.of(phase), List.of())
+                .build();
+
+        ResolvedVariableContext ctx = engine.resolveVariables(template, COMMON, new Random(42L));
+
+        assertEquals(1.0, ctx.poolDifficulty(), 0.0001, "Pool difficulty should default to 1.0 when no pools exist");
+        assertEquals(1.0, ctx.rarityDifficulty(), 0.0001);
+        assertEquals(1.0, ctx.difficulty(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("Given template with no variables, when generating, then definition is produced with literal required-progress")
+    void generate_noVariables_literalProgress() {
+        Map<String, TemplateVariable> variables = new LinkedHashMap<>();
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "50", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), variables, List.of(phase), List.of())
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, COMMON, new Random(42L));
+        QuestDefinition def = result.definition();
+        assertNotNull(def);
+        QuestObjectiveDefinition objDef = def.getPhases().get(0).getStages().get(0).getObjectives().get(0);
+        assertEquals(50L, objDef.getRequiredProgress());
+    }
+
+    @Test
+    @DisplayName("Given required-progress expression that evaluates to zero, when generating, then it is clamped to 1")
+    void generate_zeroProgress_clampedToOne() {
+        Map<String, TemplateVariable> variables = new LinkedHashMap<>();
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "0", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), variables, List.of(phase), List.of())
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, COMMON, new Random(42L));
+        QuestDefinition def = result.definition();
+        long required = def.getPhases().get(0).getStages().get(0).getObjectives().get(0)
+                .getRequiredProgress();
+        assertTrue(required >= 1, "Required progress should be clamped to at least 1, got: " + required);
+    }
+
+    @Test
+    @DisplayName("Given all phases filtered out by condition, when generating, then QuestGenerationException is thrown")
+    void generate_allPhasesFiltered_throwsQuestGenerationException() {
+        TemplateCondition alwaysFalse = mock(TemplateCondition.class);
+        when(alwaysFalse.evaluate(any())).thenReturn(false);
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage), alwaysFalse);
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), Map.of(), List.of(phase), List.of())
+                .build();
+
+        assertThrows(QuestGenerationException.class,
+                () -> engine.generate(template, COMMON, new Random(42L)),
+                "Should throw when all phases are filtered out by conditions");
+    }
+
+    @Test
+    @DisplayName("Given phase with condition that passes, when generating, then phase is included")
+    void generate_phaseConditionPasses_phaseIncluded() {
+        TemplateCondition alwaysTrue = mock(TemplateCondition.class);
+        when(alwaysTrue.evaluate(any())).thenReturn(true);
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage), alwaysTrue);
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), Map.of(), List.of(phase), List.of())
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, COMMON, new Random(42L));
+        assertEquals(1, result.definition().getPhases().size());
+    }
+
+    @Test
+    @DisplayName("Given reward with literal 'amount' numeric value, when generating with multiplier > 1, then amount is scaled")
+    void generate_rewardNumericAmount_scaledByMultiplier() {
+        NamespacedKey rareKey = NamespacedKey.fromString("mcrpg:rare");
+        when(rarityRegistry.get(rareKey)).thenReturn(Optional.of(
+                new QuestRarity(rareKey, 5, 1.5, 2.0, EXPANSION_KEY)));
+
+        Map<String, TemplateVariable> variables = new LinkedHashMap<>();
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        TemplateRewardDefinition reward = new TemplateRewardDefinition(
+                REWARD_TYPE_KEY, "xp_reward",
+                Map.of("amount", 100, "display-label", "Experience"));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(rareKey), Map.of(), variables, List.of(phase), List.of(reward))
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, rareKey, new Random(42L));
+        QuestRewardType generatedReward = result.definition().getRewards().get(0);
+        Map<String, Object> config = generatedReward.serializeConfig();
+        long amount = ((Number) config.get("amount")).longValue();
+        assertEquals(200L, amount, "Amount 100 * RARE reward multiplier 2.0 should equal 200");
+    }
+
+    @Test
+    @DisplayName("Given reward with non-amount key and numeric value, when generating, then value is not scaled by multiplier")
+    void generate_rewardNonAmountNumericKey_notScaled() {
+        Map<String, TemplateVariable> variables = new LinkedHashMap<>();
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        TemplateRewardDefinition reward = new TemplateRewardDefinition(
+                REWARD_TYPE_KEY, "xp_reward",
+                Map.of("amount", 100, "some-count", 5));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), variables, List.of(phase), List.of(reward))
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, COMMON, new Random(42L));
+        Map<String, Object> config = result.definition().getRewards().get(0).serializeConfig();
+        assertEquals(5, ((Number) config.get("some-count")).intValue(),
+                "Non-amount keys should not be scaled by reward multiplier");
+    }
+
+    @Test
+    @DisplayName("Given unsupported rarity, when generating, then IllegalArgumentException is thrown")
+    void generate_unsupportedRarity_throws() {
+        NamespacedKey unsupported = NamespacedKey.fromString("mcrpg:legendary");
+        when(rarityRegistry.get(unsupported)).thenReturn(Optional.of(
+                new QuestRarity(unsupported, 1, 3.0, 3.0, EXPANSION_KEY)));
+
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), Map.of(), List.of(phase), List.of())
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> engine.generate(template, unsupported, new Random(42L)),
+                "Should throw for rarity not in template's supported set");
+    }
+
+    @Test
+    @DisplayName("Given multiple phases, when generating, then all phases appear in the definition")
+    void generate_multiplePhases_allIncluded() {
+        TemplateObjectiveDefinition obj1 = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage1 = new TemplateStageDefinition(List.of(obj1));
+        TemplatePhaseDefinition phase1 = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage1));
+
+        TemplateObjectiveDefinition obj2 = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "20", Map.of());
+        TemplateStageDefinition stage2 = new TemplateStageDefinition(List.of(obj2));
+        TemplatePhaseDefinition phase2 = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ANY, List.of(stage2));
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), Map.of(), List.of(phase1, phase2), List.of())
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, COMMON, new Random(42L));
+        assertEquals(2, result.definition().getPhases().size());
+        assertEquals(PhaseCompletionMode.ALL, result.definition().getPhases().get(0).getCompletionMode());
+        assertEquals(PhaseCompletionMode.ANY, result.definition().getPhases().get(1).getCompletionMode());
+    }
+
+    @Test
+    @DisplayName("Given template with inline display, when generating, then display keys are present on definition")
+    void generate_inlineDisplay_preservedOnDefinition() {
+        TemplateObjectiveDefinition objective = new TemplateObjectiveDefinition(
+                OBJECTIVE_TYPE_KEY, "10", Map.of());
+        TemplateStageDefinition stage = new TemplateStageDefinition(List.of(objective));
+        TemplatePhaseDefinition phase = new TemplatePhaseDefinition(
+                PhaseCompletionMode.ALL, List.of(stage));
+
+        Map<String, String> inlineDisplay = Map.of(
+                "name", "Mining Quest",
+                "description", "Mine some blocks");
+
+        QuestTemplate template = new QuestTemplate.Builder(TEMPLATE_KEY,
+                Route.fromString("quests.templates.test.display-name"), SCOPE_KEY,
+                Set.of(COMMON), Map.of(), Map.of(), List.of(phase), List.of())
+                .inlineDisplay(inlineDisplay)
+                .build();
+
+        GeneratedQuestResult result = engine.generate(template, COMMON, new Random(42L));
+        Map<String, String> display = result.definition().getInlineDisplay();
+        assertEquals("Mining Quest", display.get("name"));
+        assertEquals("Mine some blocks", display.get("description"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 36 new unit tests across 3 new test files to improve coverage for the quest configuration loading and template generation pipeline.

### New Test Files

- **`QuestConfigLoaderBoardMetadataTest`** (15 tests) — Covers board metadata parsing (all fields, board-eligible false, absent metadata), inline display (all fields, absent), on-start messages (locale key, inline, mixed, absent, invalid entries), chain file detection, COOLDOWN_LIMITED repeat mode with missing fields, expiration combined format, invalid completion mode, missing phases, and duplicate quest key handling.

- **`QuestTemplateConfigLoaderExtendedTest`** (11 tests) — Covers weighted random objective selection config parsing, absent objective selection, reward definitions (present and absent), inline display, expression validation (undeclared variables in required-progress and rewards, invalid syntax), pool variable references in objective config, and structural error paths (no phases, empty objectives, built-in difficulty variable).

- **`QuestTemplateEngineEdgeCaseTest`** (10 tests) — Covers variable resolution edge cases (no pool variables defaults difficulty to 1.0, no variables with literal progress), zero-progress clamping to minimum 1, condition-based phase filtering (all filtered throws exception, passing condition includes phase), reward multiplier scaling (amount key scaled, non-amount key preserved), unsupported rarity rejection, multi-phase generation, and inline display preservation.

### Target Classes & Prior Coverage

| Class | Missed Instructions (Before) |
|-------|------------------------------|
| `QuestConfigLoader` | 623 |
| `QuestTemplateConfigLoader` | 322 |
| `QuestTemplateEngine` | 208 |

### Test Patterns Used

- `McRPGBaseTest` for `QuestConfigLoader` tests (requires Bukkit/MockBukkit for `NamespacedKey` and registry access)
- Plain JUnit with `@TempDir` for `QuestTemplateConfigLoader` tests (no Bukkit dependency needed)
- Mockito mocks for `QuestTemplateEngine` tests (mock registries, objective types, reward types)
- `TestFileUtils` from `testFixtures` for filesystem helpers

## Test plan

- [x] All 36 new tests pass
- [x] Full test suite passes with zero failures (5113+ tests)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pDGBaQZqHUeGvhKuH7CV8

---
_Generated by [Claude Code](https://claude.ai/code/session_013pDGBaQZqHUeGvhKuH7CV8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for quest configuration parsing, including board metadata, displays, start messages, repeat modes, expiration, and validation behavior.
  * Added coverage for quest template loading, objective selection, rewards, variable validation, and invalid template handling.
  * Added edge-case coverage for quest generation, including difficulty defaults, progress limits, conditional phases, reward scaling, rarity validation, and inline displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->